### PR TITLE
Add real API tests for additional providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,7 @@ test = [
     "openai>=1.97.1",
     "pytest>=8.3.5",
     "python-dotenv>=1.0.1",
+    "anthropic>=0.25.0",
+    "google-generativeai>=0.5.0",
+    "boto3>=1.34.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ print("AICM_API_KEY (pre-force):", os.environ.get("AICM_API_KEY"))
 print("AICM_API_BASE:", os.environ.get("AICM_API_BASE"))
 print("AICM_INI_PATH:", os.environ.get("AICM_INI_PATH"))
 print("OPENAI_API_KEY (pre-force):", os.environ.get("OPENAI_API_KEY"))
+print("ANTHROPIC_API_KEY (pre-force):", os.environ.get("ANTHROPIC_API_KEY"))
+print("GOOGLE_API_KEY (pre-force):", os.environ.get("GOOGLE_API_KEY"))
+print("AWS_DEFAULT_REGION:", os.environ.get("AWS_DEFAULT_REGION"))
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -28,12 +31,21 @@ def force_api_keys():
     load_dotenv(ENV_PATH, override=True)
     aicm_key = os.environ.get("AICM_API_KEY")
     openai_key = os.environ.get("OPENAI_API_KEY")
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    google_key = os.environ.get("GOOGLE_API_KEY")
+    aws_region = os.environ.get("AWS_DEFAULT_REGION")
     if not aicm_key:
         pytest.skip("AICM_API_KEY not set in .env file")
     if not openai_key:
         print("WARNING: OPENAI_API_KEY not set in .env file (some tests may skip)")
     os.environ["AICM_API_KEY"] = aicm_key
     os.environ["OPENAI_API_KEY"] = openai_key or ""
+    if anthropic_key:
+        os.environ["ANTHROPIC_API_KEY"] = anthropic_key
+    if google_key:
+        os.environ["GOOGLE_API_KEY"] = google_key
+    if aws_region:
+        os.environ["AWS_DEFAULT_REGION"] = aws_region
     print("AICM_API_KEY (forced):", os.environ.get("AICM_API_KEY"))
     print("OPENAI_API_KEY (forced):", os.environ.get("OPENAI_API_KEY"))
     yield
@@ -50,6 +62,21 @@ def aicm_api_key():
 @pytest.fixture(scope="session")
 def openai_api_key():
     return os.environ.get("OPENAI_API_KEY")
+
+
+@pytest.fixture(scope="session")
+def anthropic_api_key():
+    return os.environ.get("ANTHROPIC_API_KEY")
+
+
+@pytest.fixture(scope="session")
+def google_api_key():
+    return os.environ.get("GOOGLE_API_KEY")
+
+
+@pytest.fixture(scope="session")
+def aws_region():
+    return os.environ.get("AWS_DEFAULT_REGION")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_anthropic_real_cost_manager.py
+++ b/tests/test_anthropic_real_cost_manager.py
@@ -1,0 +1,364 @@
+import json
+import time
+
+import pytest
+import requests
+
+anthropic = pytest.importorskip("anthropic")
+from aicostmanager import CostManager, UniversalExtractor
+
+
+def verify_event_delivered(aicm_api_key, aicm_api_base, response_id, timeout=10, max_attempts=8):
+    headers = {
+        "Authorization": f"Bearer {aicm_api_key}",
+        "Content-Type": "application/json",
+    }
+    for attempt in range(max_attempts):
+        try:
+            events_response = requests.get(
+                f"{aicm_api_base}/api/v1/usage/events/",
+                headers=headers,
+                params={"limit": 20},
+                timeout=timeout,
+            )
+            if events_response.status_code == 200:
+                events_data = events_response.json()
+                results = events_data.get("results", [])
+                for event in results:
+                    if event.get("response_id") == response_id:
+                        return event
+            if attempt < max_attempts - 1:
+                time.sleep(3)
+        except Exception:
+            if attempt < max_attempts - 1:
+                time.sleep(3)
+    return None
+
+
+def _make_client(api_key):
+    return anthropic.Anthropic(api_key=api_key)
+
+
+def test_anthropic_cost_manager_configs(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    anth_configs = [c for c in configs if c.api_id == "anthropic"]
+    assert anth_configs
+
+
+def test_anthropic_config_retrieval_and_extractor_interaction(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    anth_configs = [cfg for cfg in configs if cfg.api_id == "anthropic"]
+    assert anth_configs
+    extractor = UniversalExtractor(anth_configs)
+    for config in anth_configs:
+        handling = config.handling_config
+        assert isinstance(handling, dict)
+        assert "tracked_methods" in handling
+        assert "request_fields" in handling
+        assert "response_fields" in handling
+        assert "payload_mapping" in handling
+
+
+def test_anthropic_messages_with_dad_joke(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    resp = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        max_tokens=100,
+    )
+    assert resp is not None
+    assert hasattr(resp, "content")
+    assert resp.content
+
+
+def test_anthropic_messages_streaming_with_dad_joke(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    stream = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        max_tokens=100,
+        stream=True,
+    )
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+        if hasattr(chunk, "delta") and getattr(chunk.delta, "text", None):
+            full += chunk.delta.text
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_anthropic_completion_with_dad_joke(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    resp = tracked_client.completions.create(
+        model="claude-3-haiku-20240307",
+        prompt="Tell me a dad joke.",
+        max_tokens=100,
+    )
+    assert resp is not None
+    assert hasattr(resp, "completion")
+
+
+def test_anthropic_completion_streaming_with_dad_joke(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    stream = tracked_client.completions.create(
+        model="claude-3-haiku-20240307",
+        prompt="Tell me a dad joke.",
+        max_tokens=100,
+        stream=True,
+    )
+    chunk_count = 0
+    full = ""
+    for chunk in stream:
+        chunk_count += 1
+        text = getattr(chunk, "completion", None)
+        if text:
+            full += text
+        if hasattr(chunk, "delta") and getattr(chunk.delta, "completion", None):
+            full += chunk.delta.completion
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_anthropic_responses_api_with_dad_joke(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    resp = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+    )
+    assert resp is not None
+    assert hasattr(resp, "content")
+    assert resp.content
+
+
+def test_anthropic_responses_api_streaming_with_dad_joke(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    stream = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        stream=True,
+    )
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+        if hasattr(chunk, "delta") and getattr(chunk.delta, "text", None):
+            full += chunk.delta.text
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_extractor_payload_generation(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    anth_configs = [cfg for cfg in configs if cfg.api_id == "anthropic"]
+    extractor = UniversalExtractor(anth_configs)
+    resp = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        max_tokens=50,
+    )
+    for config in anth_configs:
+        tracking_data = extractor._build_tracking_data(
+            config,
+            "messages.create",
+            (),
+            {
+                "model": "claude-3-haiku-20240307",
+                "messages": [{"role": "user", "content": "Tell me a dad joke."}],
+                "max_tokens": 50,
+            },
+            resp,
+            client,
+        )
+        assert "timestamp" in tracking_data
+        assert "method" in tracking_data
+        assert "config_identifier" in tracking_data
+        assert "request_data" in tracking_data
+        assert "response_data" in tracking_data
+        assert "client_data" in tracking_data
+        assert "usage_data" in tracking_data
+
+
+def test_anthropic_messages_usage_delivery(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        max_tokens=50,
+    )
+    event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.id)
+    assert event is not None
+    assert "usage" in event
+
+
+def test_anthropic_messages_streaming_usage_delivery(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    stream = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        max_tokens=50,
+        stream=True,
+    )
+    response_id = None
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if hasattr(chunk, "id"):
+            response_id = chunk.id
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+        if hasattr(chunk, "delta") and getattr(chunk.delta, "text", None):
+            full += chunk.delta.text
+    assert chunk_count > 0
+    assert full.strip()
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_anthropic_responses_api_usage_delivery(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+    )
+    event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.id)
+    assert event is not None
+    assert "usage" in event
+
+
+def test_anthropic_responses_api_streaming_usage_delivery(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    stream = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        stream=True,
+    )
+    response_id = None
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if hasattr(chunk, "id"):
+            response_id = chunk.id
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+        if hasattr(chunk, "delta") and getattr(chunk.delta, "text", None):
+            full += chunk.delta.text
+    assert chunk_count > 0
+    assert full.strip()
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_usage_payload_delivery_verification(anthropic_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(anthropic_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = tracked_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Tell me a dad joke."}],
+        max_tokens=50,
+    )
+    event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.id)
+    assert event is not None
+    assert "usage" in event
+    usage = event["usage"]
+    assert isinstance(usage, dict)
+    if "prompt_tokens" in usage:
+        assert isinstance(usage["prompt_tokens"], (int, float))
+    if "completion_tokens" in usage:
+        assert isinstance(usage["completion_tokens"], (int, float))
+    if "total_tokens" in usage:
+        assert isinstance(usage["total_tokens"], (int, float))

--- a/tests/test_bedrock_real_cost_manager.py
+++ b/tests/test_bedrock_real_cost_manager.py
@@ -1,0 +1,342 @@
+import json
+import time
+
+import pytest
+import requests
+
+boto3 = pytest.importorskip("boto3")
+from aicostmanager import CostManager, UniversalExtractor
+
+
+def verify_event_delivered(aicm_api_key, aicm_api_base, response_id, timeout=10, max_attempts=8):
+    headers = {
+        "Authorization": f"Bearer {aicm_api_key}",
+        "Content-Type": "application/json",
+    }
+    for attempt in range(max_attempts):
+        try:
+            events_response = requests.get(
+                f"{aicm_api_base}/api/v1/usage/events/",
+                headers=headers,
+                params={"limit": 20},
+                timeout=timeout,
+            )
+            if events_response.status_code == 200:
+                events_data = events_response.json()
+                results = events_data.get("results", [])
+                for event in results:
+                    if event.get("response_id") == response_id:
+                        return event
+            if attempt < max_attempts - 1:
+                time.sleep(3)
+        except Exception:
+            if attempt < max_attempts - 1:
+                time.sleep(3)
+    return None
+
+
+def _make_client(region):
+    return boto3.client("bedrock-runtime", region_name=region)
+
+
+def _invoke(client, model_id, prompt, stream=False):
+    body = {
+        "prompt": prompt,
+        "max_gen_len": 100,
+        "temperature": 0.5,
+    }
+    if stream:
+        response = client.invoke_model_with_response_stream(
+            modelId=model_id,
+            body=json.dumps(body),
+            accept="application/json",
+            contentType="application/json",
+        )
+        return response["body"]
+    else:
+        resp = client.invoke_model(
+            modelId=model_id,
+            body=json.dumps(body),
+            accept="application/json",
+            contentType="application/json",
+        )
+        return json.loads(resp["body"].read())
+
+
+def test_bedrock_cost_manager_configs(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    br_configs = [c for c in configs if c.api_id == "bedrock"]
+    assert br_configs
+
+
+def test_bedrock_config_retrieval_and_extractor_interaction(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    br_configs = [cfg for cfg in configs if cfg.api_id == "bedrock"]
+    assert br_configs
+    extractor = UniversalExtractor(br_configs)
+    for config in br_configs:
+        handling = config.handling_config
+        assert isinstance(handling, dict)
+        assert "tracked_methods" in handling
+        assert "request_fields" in handling
+        assert "response_fields" in handling
+        assert "payload_mapping" in handling
+
+
+def test_bedrock_invoke_model_with_dad_joke(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    resp = _invoke(tracked_client, "us.meta.llama3-3-70b-instruct-v1:0", "Tell me a dad joke.")
+    assert resp
+
+
+def test_bedrock_invoke_model_streaming_with_dad_joke(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    stream = _invoke(tracked_client, "us.meta.llama3-3-70b-instruct-v1:0", "Tell me a dad joke.", stream=True)
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if "bytes" in chunk:
+            try:
+                data = json.loads(chunk["bytes"].decode("utf-8"))
+                text = data.get("generation") or data.get("output")
+                if text:
+                    full += text
+            except Exception:
+                pass
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_bedrock_completion_with_dad_joke(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    resp = _invoke(tracked_client, "us.amazon.nova-pro-v1:0", "Tell me a dad joke.")
+    assert resp
+
+
+def test_bedrock_completion_streaming_with_dad_joke(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    stream = _invoke(tracked_client, "us.amazon.nova-pro-v1:0", "Tell me a dad joke.", stream=True)
+    chunk_count = 0
+    full = ""
+    for chunk in stream:
+        chunk_count += 1
+        if "bytes" in chunk:
+            try:
+                data = json.loads(chunk["bytes"].decode("utf-8"))
+                text = data.get("generation") or data.get("output")
+                if text:
+                    full += text
+            except Exception:
+                pass
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_bedrock_responses_api_with_dad_joke(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    resp = _invoke(tracked_client, "us.amazon.nova-pro-v1:0", "Tell me a dad joke.")
+    assert resp
+
+
+def test_bedrock_responses_api_streaming_with_dad_joke(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    stream = _invoke(tracked_client, "us.amazon.nova-pro-v1:0", "Tell me a dad joke.", stream=True)
+    chunk_count = 0
+    full = ""
+    for chunk in stream:
+        chunk_count += 1
+        if "bytes" in chunk:
+            try:
+                data = json.loads(chunk["bytes"].decode("utf-8"))
+                text = data.get("generation") or data.get("output")
+                if text:
+                    full += text
+            except Exception:
+                pass
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_extractor_payload_generation(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    br_configs = [cfg for cfg in configs if cfg.api_id == "bedrock"]
+    extractor = UniversalExtractor(br_configs)
+    resp = _invoke(tracked_client, "us.meta.llama3-3-70b-instruct-v1:0", "Tell me a dad joke.")
+    for config in br_configs:
+        tracking_data = extractor._build_tracking_data(
+            config,
+            "invoke_model",
+            (),
+            {
+                "modelId": "us.meta.llama3-3-70b-instruct-v1:0",
+                "prompt": "Tell me a dad joke.",
+            },
+            resp,
+            client,
+        )
+        assert "timestamp" in tracking_data
+        assert "method" in tracking_data
+        assert "config_identifier" in tracking_data
+        assert "request_data" in tracking_data
+        assert "response_data" in tracking_data
+        assert "client_data" in tracking_data
+        assert "usage_data" in tracking_data
+
+
+def test_bedrock_invoke_model_usage_delivery(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = _invoke(tracked_client, "us.meta.llama3-3-70b-instruct-v1:0", "Tell me a dad joke.")
+    response_id = resp.get("response_id") or resp.get("id")
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_bedrock_invoke_model_streaming_usage_delivery(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    stream = _invoke(tracked_client, "us.meta.llama3-3-70b-instruct-v1:0", "Tell me a dad joke.", stream=True)
+    response_id = None
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if "bytes" in chunk:
+            try:
+                data = json.loads(chunk["bytes"].decode("utf-8"))
+                response_id = response_id or data.get("response_id")
+            except Exception:
+                pass
+    assert chunk_count > 0
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_bedrock_responses_api_usage_delivery(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = _invoke(tracked_client, "us.amazon.nova-pro-v1:0", "Tell me a dad joke.")
+    response_id = resp.get("response_id") or resp.get("id")
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_bedrock_responses_api_streaming_usage_delivery(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    stream = _invoke(tracked_client, "us.amazon.nova-pro-v1:0", "Tell me a dad joke.", stream=True)
+    response_id = None
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if "bytes" in chunk:
+            try:
+                data = json.loads(chunk["bytes"].decode("utf-8"))
+                response_id = response_id or data.get("response_id")
+            except Exception:
+                pass
+    assert chunk_count > 0
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_usage_payload_delivery_verification(aws_region, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(aws_region)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = _invoke(tracked_client, "us.meta.llama3-3-70b-instruct-v1:0", "Tell me a dad joke.")
+    response_id = resp.get("response_id") or resp.get("id")
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+        usage = event["usage"]
+        assert isinstance(usage, dict)
+        if "prompt_tokens" in usage:
+            assert isinstance(usage["prompt_tokens"], (int, float))
+        if "completion_tokens" in usage:
+            assert isinstance(usage["completion_tokens"], (int, float))
+        if "total_tokens" in usage:
+            assert isinstance(usage["total_tokens"], (int, float))

--- a/tests/test_gemini_real_cost_manager.py
+++ b/tests/test_gemini_real_cost_manager.py
@@ -1,0 +1,301 @@
+import json
+import time
+
+import pytest
+import requests
+
+genai = pytest.importorskip("google.generativeai")
+from aicostmanager import CostManager, UniversalExtractor
+
+
+def verify_event_delivered(aicm_api_key, aicm_api_base, response_id, timeout=10, max_attempts=8):
+    headers = {
+        "Authorization": f"Bearer {aicm_api_key}",
+        "Content-Type": "application/json",
+    }
+    for attempt in range(max_attempts):
+        try:
+            events_response = requests.get(
+                f"{aicm_api_base}/api/v1/usage/events/",
+                headers=headers,
+                params={"limit": 20},
+                timeout=timeout,
+            )
+            if events_response.status_code == 200:
+                events_data = events_response.json()
+                results = events_data.get("results", [])
+                for event in results:
+                    if event.get("response_id") == response_id:
+                        return event
+            if attempt < max_attempts - 1:
+                time.sleep(3)
+        except Exception:
+            if attempt < max_attempts - 1:
+                time.sleep(3)
+    return None
+
+
+def _make_client(api_key):
+    genai.configure(api_key=api_key)
+    return genai.GenerativeModel("gemini-pro")
+
+
+def test_gemini_cost_manager_configs(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    gem_configs = [c for c in configs if c.api_id == "gemini"]
+    assert gem_configs
+
+
+def test_gemini_config_retrieval_and_extractor_interaction(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    gem_configs = [cfg for cfg in configs if cfg.api_id == "gemini"]
+    assert gem_configs
+    extractor = UniversalExtractor(gem_configs)
+    for config in gem_configs:
+        handling = config.handling_config
+        assert isinstance(handling, dict)
+        assert "tracked_methods" in handling
+        assert "request_fields" in handling
+        assert "response_fields" in handling
+        assert "payload_mapping" in handling
+
+
+def test_gemini_generate_content_with_dad_joke(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    assert resp is not None
+    text = getattr(resp, "text", None)
+    assert text
+
+
+def test_gemini_generate_content_streaming_with_dad_joke(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    stream = tracked_client.generate_content("Tell me a dad joke.", stream=True)
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_gemini_completion_with_dad_joke(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    assert resp is not None
+    assert getattr(resp, "text", None)
+
+
+def test_gemini_completion_streaming_with_dad_joke(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    stream = tracked_client.generate_content("Tell me a dad joke.", stream=True)
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_gemini_responses_api_with_dad_joke(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    assert resp is not None
+    assert getattr(resp, "text", None)
+
+
+def test_gemini_responses_api_streaming_with_dad_joke(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    stream = tracked_client.generate_content("Tell me a dad joke.", stream=True)
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+    assert chunk_count > 0
+    assert full.strip()
+
+
+def test_extractor_payload_generation(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(client)
+    configs = tracked_client.configs
+    gem_configs = [cfg for cfg in configs if cfg.api_id == "gemini"]
+    extractor = UniversalExtractor(gem_configs)
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    for config in gem_configs:
+        tracking_data = extractor._build_tracking_data(
+            config,
+            "generate_content",
+            (),
+            {"prompt": "Tell me a dad joke."},
+            resp,
+            client,
+        )
+        assert "timestamp" in tracking_data
+        assert "method" in tracking_data
+        assert "config_identifier" in tracking_data
+        assert "request_data" in tracking_data
+        assert "response_data" in tracking_data
+        assert "client_data" in tracking_data
+        assert "usage_data" in tracking_data
+
+
+def test_gemini_generate_content_usage_delivery(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.response_id)
+    assert event is not None
+    assert "usage" in event
+
+
+def test_gemini_generate_content_streaming_usage_delivery(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    stream = tracked_client.generate_content("Tell me a dad joke.", stream=True)
+    response_id = None
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if hasattr(chunk, "response_id"):
+            response_id = chunk.response_id
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+    assert chunk_count > 0
+    assert full.strip()
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_gemini_responses_api_usage_delivery(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.response_id)
+    assert event is not None
+    assert "usage" in event
+
+
+def test_gemini_responses_api_streaming_usage_delivery(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    stream = tracked_client.generate_content("Tell me a dad joke.", stream=True)
+    response_id = None
+    full = ""
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if hasattr(chunk, "response_id"):
+            response_id = chunk.response_id
+        text = getattr(chunk, "text", None)
+        if text:
+            full += text
+    assert chunk_count > 0
+    assert full.strip()
+    if response_id:
+        event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
+        assert event is not None
+        assert "usage" in event
+
+
+def test_usage_payload_delivery_verification(google_api_key, aicm_api_key, aicm_api_base, aicm_ini_path, clean_delivery):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    if not aicm_api_key:
+        pytest.skip("AICM_API_KEY not set in .env file")
+    client = _make_client(google_api_key)
+    tracked_client = CostManager(
+        client,
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=aicm_api_base,
+        aicm_ini_path=aicm_ini_path,
+    )
+    resp = tracked_client.generate_content("Tell me a dad joke.")
+    event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.response_id)
+    assert event is not None
+    assert "usage" in event
+    usage = event["usage"]
+    assert isinstance(usage, dict)
+    if "prompt_tokens" in usage:
+        assert isinstance(usage["prompt_tokens"], (int, float))
+    if "completion_tokens" in usage:
+        assert isinstance(usage["completion_tokens"], (int, float))
+    if "total_tokens" in usage:
+        assert isinstance(usage["total_tokens"], (int, float))


### PR DESCRIPTION
## Summary
- add Anthropic, Gemini and Bedrock real API tests
- extend fixture setup for new provider keys
- add Anthropic, Google Gemini and Boto3 to test dependencies

## Testing
- `pip install -e .` *(fails: Tunnel connection failed)*
- `pytest -k 'real_cost_manager' -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_688236465674832b9276fa453fba09ad