### PR TITLE
Improve README usage docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,14 @@
+# Running the test suite
+
+1. Ensure you have [`uv`](https://github.com/astral-sh/uv) installed.
+2. Create a virtual environment and install dependencies:
+
+   ```bash
+   uv venv
+   source .venv/bin/activate
+   uv pip install -e . openai pytest python-dotenv
+   ```
+
+3. Add a `.env` file inside the `tests/` directory with values for at least `AICM_API_KEY` and any provider keys you plan to test (for example `OPENAI_API_KEY`).  Without a valid `AICM_API_KEY` the tracking wrapper cannot deliver usage data.
+
+4. Run `pytest` to execute the suite.


### PR DESCRIPTION
## Summary
- rewrite README with uv-first install, OpenAI usage examples and delivery docs
- document events API usage
- add instructions for test setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6882ad43ecd8832b95dee0134b1da6ac