### PR TITLE
Handle updated triggered limit vendor structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Added /dist/* to gitignore
 
+## [0.1.6] - 2025-07-24
+### Changed
+- Updated `TriggeredLimit` structure. Vendor details now provide
+  `config_id_list` and `hostname` values. The old `vendor` string field
+  has been removed.
+
 ## [0.1.3] - 2025-07-24
 ### Added
 - Initial release of the AICostManager Python SDK

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -51,7 +51,11 @@ def _make_triggered_limits():
         "threshold_type": "limit",
         "amount": 10.0,
         "period": "day",
-        "vendor": "openai",
+        "vendor": {
+            "name": "openai",
+            "config_ids": ["cfg1"],
+            "hostname": "api.openai.com",
+        },
         "service_id": "gpt-4",
         "client_customer_key": "cust1",
         "api_key_id": "api-key-id",
@@ -98,6 +102,8 @@ def test_get_config_and_limits(monkeypatch, tmp_path):
     limits = cfg_mgr.get_triggered_limits(service_id="gpt-4")
     assert len(limits) == 1
     assert limits[0].service_id == "gpt-4"
+    assert limits[0].config_id_list == ["cfg1"]
+    assert limits[0].hostname == "api.openai.com"
 
     # file written
     cp = configparser.ConfigParser()


### PR DESCRIPTION
## Summary
- update `TriggeredLimit` dataclass
- parse new `vendor` structure in `get_triggered_limits`
- adjust tests for the new format
- document the change in `CHANGELOG`

## Testing
- `ruff format aicostmanager/config_manager.py tests/test_config_manager.py` *(no output)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_b_688697fa2164832bb27cb261969d92b4