### PR TITLE
Update usage management endpoints

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -30,6 +30,8 @@ from .models import (
     UsageEventFilters,
     UsageLimitIn,
     UsageLimitOut,
+    VendorOut,
+    ServiceOut,
     UsageRollup,
     ValidationError,
 )
@@ -54,6 +56,8 @@ __all__ = [
     "CustomerOut",
     "UsageLimitIn",
     "UsageLimitOut",
+    "VendorOut",
+    "ServiceOut",
     "ThresholdType",
     "Period",
     "Granularity",

--- a/aicostmanager/client.py
+++ b/aicostmanager/client.py
@@ -20,6 +20,8 @@ from .models import (
     UsageEvent,
     UsageLimitIn,
     UsageLimitOut,
+    VendorOut,
+    ServiceOut,
     UsageRollup,
     UsageEventFilters,
     RollupFilters,
@@ -312,6 +314,14 @@ class CostManagerClient:
         self._request("DELETE", f"/usage-limits/{limit_id}/")
         return None
 
+    def list_vendors(self) -> Iterable[VendorOut]:
+        data = self._request("GET", "/vendors/")
+        return [VendorOut.model_validate(i) for i in data]
+
+    def list_vendor_services(self, vendor: str) -> Iterable[ServiceOut]:
+        data = self._request("GET", "/services/", params={"vendor": vendor})
+        return [ServiceOut.model_validate(i) for i in data]
+
     def get_openapi_schema(self) -> Any:
         return self._request("GET", "/openapi.json")
 
@@ -547,6 +557,14 @@ class AsyncCostManagerClient:
     async def delete_usage_limit(self, limit_id: str) -> None:
         await self._request("DELETE", f"/usage-limits/{limit_id}/")
         return None
+
+    async def list_vendors(self) -> Iterable[VendorOut]:
+        data = await self._request("GET", "/vendors/")
+        return [VendorOut.model_validate(i) for i in data]
+
+    async def list_vendor_services(self, vendor: str) -> Iterable[ServiceOut]:
+        data = await self._request("GET", "/services/", params={"vendor": vendor})
+        return [ServiceOut.model_validate(i) for i in data]
 
     async def get_openapi_schema(self) -> Any:
         return await self._request("GET", "/openapi.json")

--- a/aicostmanager/models.py
+++ b/aicostmanager/models.py
@@ -128,6 +128,22 @@ class UsageLimitOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class VendorOut(BaseModel):
+    uuid: str
+    name: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ServiceOut(BaseModel):
+    uuid: str
+    service_id: str
+    vendor: str
+    name: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class UsageEvent(BaseModel):
     event_id: str
     config_id: str

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,3 +64,17 @@ async def async_example():
         async with AsyncCostManager(aclient) as manager:
             await manager.client.list_customers()
 ```
+
+## Vendor & Service Lookup
+
+You can retrieve available vendors and their services:
+
+```python
+vendors = client.list_vendors()
+for vendor in vendors:
+    print(vendor.name)
+    services = client.list_vendor_services(vendor.uuid)
+    for svc in services:
+        print(" -", svc.service_id)
+```
+

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -220,6 +220,15 @@ def test_async_methods(monkeypatch):
             None,
             204,
         ),
+        ("GET", "/vendors/", client.list_vendors, (), {}, []),
+        (
+            "GET",
+            "/services/",
+            client.list_vendor_services,
+            (),
+            {"vendor": "openai"},
+            [],
+        ),
         (
             "GET",
             "/openapi.json",
@@ -285,6 +294,12 @@ def test_async_filter_objects(monkeypatch):
 
     asyncio.run(run3())
     assert captured.get("params") == {"phone": "p", "limit": 3}
+
+    async def run4():
+        await client.list_vendor_services("openai")
+
+    asyncio.run(run4())
+    assert captured.get("params") == {"vendor": "openai"}
 
 
 def test_async_error_response(monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -247,6 +247,15 @@ def test_methods(monkeypatch):
             None,
             204,
         ),
+        ("GET", "/vendors/", client.list_vendors, (), {}, []),
+        (
+            "GET",
+            "/services/",
+            client.list_vendor_services,
+            (),
+            {"vendor": "openai"},
+            [],
+        ),
         (
             "GET",
             "/openapi.json",
@@ -326,6 +335,9 @@ def test_filter_objects(monkeypatch):
     filters = CustomerFilters(name="n", limit=2)
     client.list_customers(filters)
     assert captured.get("params") == {"name": "n", "limit": 2}
+
+    client.list_vendor_services("openai")
+    assert captured.get("params") == {"vendor": "openai"}
 
 
 def test_track_usage_persists_triggered_limits(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- support vendors and services in models and client
- expose new API endpoints on sync and async clients
- document how to list vendors and services
- test vendor/service support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6886e6efe028832bb5317838911f1b16