### PR TITLE
Refresh triggered limits on 304

### DIFF
--- a/aicostmanager/config_manager.py
+++ b/aicostmanager/config_manager.py
@@ -213,19 +213,15 @@ class CostManagerConfig:
 
         data = self.client.get_configs(etag=etag)
         if data is None:
-            # No config changes. Only fetch triggered limits if they are missing
-            if (
-                "triggered_limits" not in self._config
-                or "payload" not in self._config["triggered_limits"]
-            ):
-                try:
-                    tl_payload = self.client.get_triggered_limits() or {}
-                    if isinstance(tl_payload, dict):
-                        tl_data = tl_payload.get("triggered_limits", tl_payload)
-                        self._set_triggered_limits(tl_data)
-                        self._write()
-                except Exception:
-                    pass
+            # Config unchanged - always refresh triggered limits from the API
+            try:
+                tl_payload = self.client.get_triggered_limits() or {}
+                if isinstance(tl_payload, dict):
+                    tl_data = tl_payload.get("triggered_limits", tl_payload)
+                    self._set_triggered_limits(tl_data)
+                    self._write()
+            except Exception:
+                pass
             return
 
         if hasattr(data, "model_dump"):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,10 +56,12 @@ unchanged = client.get_configs(etag=etag)  # returns None when unchanged
 
 The `/configs` endpoint returns an `ETag` header. Send this value back in
 `If-None-Match` to avoid downloading configuration when nothing has changed.
-Triggered limit information is read from `AICM.INI` each time it is needed.
-It is fetched from the server on the initial configuration refresh (or if the
-INI file lacks the section) and whenever usage is recorded via the
-`/track-usage` endpoint.
+If the configuration is unchanged, the SDK will still refresh the
+`triggered_limits` section by calling `/triggered-limits`.
+Triggered limit information is read from `AICM.INI` each time it is needed and
+is fetched from the server only when the client is initialized (including the
+etag check described above) or when usage is recorded via the `/track-usage`
+endpoint.
 
 # using CostManager with automatic delivery
 from aicostmanager import CostManager

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -221,12 +221,12 @@ def test_config_manager_etag(monkeypatch, tmp_path):
 
     cfg_mgr.refresh()
     assert calls["configs"] == [None, "tag1"]
-    # triggered limits already stored, second refresh should not fetch them
-    assert calls["limits"] == 0
+    # second refresh should fetch triggered limits to refresh the INI
+    assert calls["limits"] == 1
 
     cp = configparser.ConfigParser()
     cp.read(ini)
-    assert json.loads(cp["triggered_limits"]["payload"]) == tl_item
+    assert json.loads(cp["triggered_limits"]["payload"]) == tl_item2
 
 
 def test_fetch_limits_when_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- fetch `/triggered-limits` whenever `/configs` returns 304
- document how triggered limits are refreshed
- update tests for changed behavior

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_b_688c8ee69a14832bb64fe4c74a13d907