### PR TITLE
Add RestCostManager wrappers

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -3,6 +3,7 @@
 __version__ = "0.1.8"
 
 from .async_cost_manager import AsyncCostManager
+from .rest_cost_manager import AsyncRestCostManager, RestCostManager
 from .client import (
     AICMError,
     APIRequestError,
@@ -51,6 +52,8 @@ __all__ = [
     "AsyncCostManager",
     "AsyncCostManagerClient",
     "CostManager",
+    "RestCostManager",
+    "AsyncRestCostManager",
     "CostManagerClient",
     "MissingConfiguration",
     "UsageLimitExceeded",

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -1,0 +1,316 @@
+"""Wrappers for generic REST clients using requests or httpx."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin, urlparse
+
+import httpx
+import requests
+
+from .async_cost_manager import AsyncResilientDelivery
+from .client import (
+    AsyncCostManagerClient,
+    CostManagerClient,
+    UsageLimitExceeded,
+)
+from .config_manager import Config, CostManagerConfig, TriggeredLimit
+from .delivery import ResilientDelivery, get_global_delivery
+from .universal_extractor import UniversalExtractor
+
+
+_HTTP_METHODS = {
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    "request",
+}
+
+
+class RestCostManager:
+    """Wrap ``requests.Session`` to track REST API calls."""
+
+    def __init__(
+        self,
+        session: Optional[requests.Session] = None,
+        *,
+        base_url: str,
+        aicm_api_key: Optional[str] = None,
+        aicm_api_base: Optional[str] = None,
+        aicm_api_url: Optional[str] = None,
+        aicm_ini_path: Optional[str] = None,
+        client_customer_key: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+        delivery: ResilientDelivery | None = None,
+        delivery_queue_size: int = 1000,
+        delivery_max_retries: int = 5,
+        delivery_timeout: float = 10.0,
+    ) -> None:
+        self.session = session or requests.Session()
+        self.base_url = base_url.rstrip("/")
+        parsed = urlparse(self.base_url if "//" in self.base_url else f"https://{self.base_url}")
+        self.hostname = parsed.netloc or parsed.path
+        self.api_id = self.hostname.lower()
+        self.client_customer_key = client_customer_key
+        self.context = context
+
+        self.cm_client = CostManagerClient(
+            aicm_api_key=aicm_api_key,
+            aicm_api_base=aicm_api_base,
+            aicm_api_url=aicm_api_url,
+            aicm_ini_path=aicm_ini_path,
+        )
+        self.config_manager = CostManagerConfig(self.cm_client)
+        self.configs: List[Config] = self.config_manager.get_config(self.api_id)
+        self.extractor = UniversalExtractor(self.configs)
+        self.tracked_payloads: List[dict[str, Any]] = []
+        self.triggered_limits: List[TriggeredLimit] = []
+
+        if delivery is not None:
+            self.delivery = delivery
+        else:
+            self.delivery = get_global_delivery(
+                self.cm_client,
+                max_retries=delivery_max_retries,
+                queue_size=delivery_queue_size,
+                timeout=delivery_timeout,
+            )
+
+    # ------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------
+    def _refresh_limits(self, service_id: str) -> None:
+        try:
+            self.triggered_limits = self.config_manager.get_triggered_limits(
+                service_id=service_id,
+                client_customer_key=self.client_customer_key,
+            )
+            blocking = [l for l in self.triggered_limits if l.threshold_type == "limit"]
+            if blocking:
+                raise UsageLimitExceeded(blocking)
+        except UsageLimitExceeded:
+            raise
+        except Exception:
+            self.triggered_limits = []
+
+    def _full_url(self, url: str) -> str:
+        if url.startswith("http"):
+            return url
+        return urljoin(self.base_url + "/", url.lstrip("/"))
+
+    def _service_id(self, url: str) -> str:
+        parsed = urlparse(url)
+        return f"{parsed.netloc}{parsed.path}"
+
+    # ------------------------------------------------------------
+    # main request method
+    # ------------------------------------------------------------
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        full = self._full_url(url)
+        service_id = self._service_id(full)
+        self._refresh_limits(service_id)
+        resp = self.session.request(method, full, **kwargs)
+        try:
+            data = resp.json()
+        except Exception:
+            data = resp.text
+        method_name = f"{method.upper()} {urlparse(full).path}"
+        payloads = self.extractor.process_call(
+            method_name,
+            (),
+            kwargs,
+            data,
+            client=self.session,
+            is_streaming=False,
+        )
+        for payload in payloads:
+            if "service_id" not in payload:
+                payload["service_id"] = service_id
+            if self.client_customer_key and "client_customer_key" not in payload:
+                payload["client_customer_key"] = self.client_customer_key
+            if self.context and "context" not in payload:
+                payload["context"] = self.context
+        if payloads:
+            self.tracked_payloads.extend(payloads)
+            for p in payloads:
+                self.delivery.deliver({"usage_records": [p]})
+        return resp
+
+    # ------------------------------------------------------------
+    # attribute proxying
+    # ------------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self.session, name)
+        if name.lower() in _HTTP_METHODS and callable(attr):
+            def wrapper(*args, **kwargs):
+                method = name if name != "request" else args[0]
+                url = args[1] if name == "request" else args[0]
+                return self.request(method, url, **kwargs)
+            return wrapper
+        return attr
+
+    def get_tracked_payloads(self) -> List[dict[str, Any]]:
+        return list(self.tracked_payloads)
+
+    # ------------------------------------------------------------
+    # delivery helpers
+    # ------------------------------------------------------------
+    def start_delivery(self) -> None:
+        self.delivery.start()
+
+    def stop_delivery(self) -> None:
+        self.delivery.stop()
+
+    def __enter__(self) -> "RestCostManager":
+        self.start_delivery()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop_delivery()
+
+
+class AsyncRestCostManager:
+    """Async wrapper for ``httpx.AsyncClient`` to track REST calls."""
+
+    def __init__(
+        self,
+        session: Optional[httpx.AsyncClient] = None,
+        *,
+        base_url: str,
+        aicm_api_key: Optional[str] = None,
+        aicm_api_base: Optional[str] = None,
+        aicm_api_url: Optional[str] = None,
+        aicm_ini_path: Optional[str] = None,
+        client_customer_key: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+        delivery: AsyncResilientDelivery | None = None,
+        delivery_queue_size: int = 1000,
+        delivery_max_retries: int = 5,
+        delivery_timeout: float = 10.0,
+    ) -> None:
+        self.session = session or httpx.AsyncClient()
+        self.base_url = base_url.rstrip("/")
+        parsed = urlparse(self.base_url if "//" in self.base_url else f"https://{self.base_url}")
+        self.hostname = parsed.netloc or parsed.path
+        self.api_id = self.hostname.lower()
+        self.client_customer_key = client_customer_key
+        self.context = context
+
+        cfg_client = CostManagerClient(
+            aicm_api_key=aicm_api_key,
+            aicm_api_base=aicm_api_base,
+            aicm_api_url=aicm_api_url,
+            aicm_ini_path=aicm_ini_path,
+        )
+        self.cm_client = AsyncCostManagerClient(
+            aicm_api_key=aicm_api_key,
+            aicm_api_base=aicm_api_base,
+            aicm_api_url=aicm_api_url,
+            aicm_ini_path=aicm_ini_path,
+        )
+        self.config_manager = CostManagerConfig(cfg_client)
+        self.configs: List[Config] = self.config_manager.get_config(self.api_id)
+        cfg_client.close()
+        self.extractor = UniversalExtractor(self.configs)
+        self.tracked_payloads: List[dict[str, Any]] = []
+        self.triggered_limits: List[TriggeredLimit] = []
+
+        if delivery is not None:
+            self.delivery = delivery
+        else:
+            self.delivery = AsyncResilientDelivery(
+                self.cm_client.session,
+                self.cm_client.api_root,
+                max_retries=delivery_max_retries,
+                queue_size=delivery_queue_size,
+                timeout=delivery_timeout,
+            )
+        self.delivery.start()
+
+    # helpers -----------------------------------------------------
+    def _full_url(self, url: str) -> str:
+        if url.startswith("http"):
+            return url
+        return urljoin(self.base_url + "/", url.lstrip("/"))
+
+    def _service_id(self, url: str) -> str:
+        parsed = urlparse(url)
+        return f"{parsed.netloc}{parsed.path}"
+
+    def _refresh_limits(self, service_id: str) -> None:
+        try:
+            self.triggered_limits = self.config_manager.get_triggered_limits(
+                service_id=service_id,
+                client_customer_key=self.client_customer_key,
+            )
+            blocking = [l for l in self.triggered_limits if l.threshold_type == "limit"]
+            if blocking:
+                raise UsageLimitExceeded(blocking)
+        except UsageLimitExceeded:
+            raise
+        except Exception:
+            self.triggered_limits = []
+
+    # main request ------------------------------------------------
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        full = self._full_url(url)
+        service_id = self._service_id(full)
+        self._refresh_limits(service_id)
+        resp = await self.session.request(method, full, **kwargs)
+        try:
+            data = resp.json()
+        except Exception:
+            data = resp.text
+        method_name = f"{method.upper()} {urlparse(full).path}"
+        payloads = self.extractor.process_call(
+            method_name,
+            (),
+            kwargs,
+            data,
+            client=self.session,
+            is_streaming=False,
+        )
+        for payload in payloads:
+            if "service_id" not in payload:
+                payload["service_id"] = service_id
+            if self.client_customer_key and "client_customer_key" not in payload:
+                payload["client_customer_key"] = self.client_customer_key
+            if self.context and "context" not in payload:
+                payload["context"] = self.context
+        if payloads:
+            self.tracked_payloads.extend(payloads)
+            for p in payloads:
+                self.delivery.deliver({"usage_records": [p]})
+        return resp
+
+    # attribute proxying ------------------------------------------
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self.session, name)
+        if name.lower() in _HTTP_METHODS and callable(attr):
+            async def wrapper(*args, **kwargs):
+                method = name if name != "request" else args[0]
+                url = args[1] if name == "request" else args[0]
+                return await self.request(method, url, **kwargs)
+            return wrapper
+        return attr
+
+    def get_tracked_payloads(self) -> List[dict[str, Any]]:
+        return list(self.tracked_payloads)
+
+    # delivery helpers -------------------------------------------
+    def start_delivery(self) -> None:
+        self.delivery.start()
+
+    async def stop_delivery(self) -> None:
+        await self.delivery.stop()
+
+    async def __aenter__(self) -> "AsyncRestCostManager":
+        self.start_delivery()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop_delivery()

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 - **[Multi-Tenant & Client Tracking](multi-tenant.md)** - Track costs across multiple clients, projects, and departments
 - [Usage](usage.md) - Basic SDK usage and API examples
 - [Tracking](tracking.md) - How the tracking system works
+- [REST API Tracking](rest.md) - Wrap requests or httpx sessions
 
 ## Development
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -1,0 +1,65 @@
+# Tracking REST APIs
+
+`RestCostManager` and `AsyncRestCostManager` make it easy to track any plain REST service accessed via `requests` or `httpx`.
+
+```python
+import requests
+from aicostmanager import RestCostManager
+
+session = requests.Session()
+tracker = RestCostManager(session, base_url="https://api.heygen.com")
+response = tracker.get("/v2/streaming.list", params={"page": 1})
+```
+
+The hostname of the API (``api.heygen.com`` in this example) becomes both the
+``api_id`` and ``config_id``. The full URL without the scheme is used as the
+``service_id``. Any payloads extracted from the call are queued for delivery to
+AICostManager just like with ``CostManager``.
+
+The response for ``/v2/streaming.list`` contains a list of streaming sessions.
+A handling configuration can iterate over those sessions and produce a usage
+record for each one. Each record's ``usage`` payload simply contains the session
+``duration``.
+
+Example delivery payload for two sessions:
+
+```json
+{
+  "usage_records": [
+    {
+      "config_id": "api.heygen.com",
+      "service_id": "api.heygen.com/v2/streaming.list",
+      "timestamp": "2024-01-01T00:00:00Z",
+      "response_id": "session-1",
+      "usage": {"duration": 12}
+    },
+    {
+      "config_id": "api.heygen.com",
+      "service_id": "api.heygen.com/v2/streaming.list",
+      "timestamp": "2024-01-01T00:00:00Z",
+      "response_id": "session-2",
+      "usage": {"duration": 20}
+    }
+  ]
+}
+```
+
+Handling configuration for this endpoint:
+
+```json
+{
+  "tracked_methods": ["GET /v2/streaming.list"],
+  "list_path": "sessions",
+  "response_fields": [
+    {"key": "session_id", "path": "session_id"},
+    {"key": "duration", "path": "duration"}
+  ],
+  "payload_mapping": {
+    "config_id": "config_identifier",
+    "service_id": "service_id",
+    "timestamp": "timestamp",
+    "response_id": "response_data.session_id",
+    "usage": "response_data.duration"
+  }
+}
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,3 +92,20 @@ for vendor in vendors:
         print(" -", svc.service_id)
 ```
 
+## Tracking Plain REST APIs
+
+Use ``RestCostManager`` (or ``AsyncRestCostManager`` for async) to track any
+service accessed via ``requests`` or ``httpx``:
+
+```python
+import requests
+from aicostmanager import RestCostManager
+
+session = requests.Session()
+tracker = RestCostManager(session, base_url="https://api.heygen.com")
+data = tracker.get("/v2/streaming.list").json()
+```
+
+The wrapper automatically extracts payloads from each call and sends them to
+AICostManager just like when using ``CostManager``.
+

--- a/tests/test_rest_cost_manager.py
+++ b/tests/test_rest_cost_manager.py
@@ -1,0 +1,128 @@
+import asyncio
+import pytest
+
+from aicostmanager.config_manager import Config, CostManagerConfig
+from aicostmanager.rest_cost_manager import RestCostManager, AsyncRestCostManager
+from aicostmanager.client import CostManagerClient, AsyncCostManagerClient
+
+
+class DummyResponse:
+    def __init__(self, data=None):
+        self.status_code = 200
+        self.headers = {"Content-Type": "application/json"}
+        self._data = data or {"value": 5}
+
+    def json(self):
+        return self._data
+
+    @property
+    def text(self):
+        import json
+
+        return json.dumps(self._data)
+
+
+class DummySession:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return DummyResponse()
+
+    def close(self):
+        pass
+
+
+class DummyAsyncSession:
+    def __init__(self):
+        self.calls = []
+
+    async def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+
+        class R:
+            status_code = 200
+            headers = {"Content-Type": "application/json"}
+
+            def json(self):
+                return {"value": 5}
+
+            text = "{}"
+
+        return R()
+
+    async def aclose(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def set_key(monkeypatch):
+    monkeypatch.setenv("AICM_API_KEY", "sk-test")
+    yield
+
+
+@pytest.fixture
+def config(monkeypatch):
+    cfg = Config(
+        uuid="cfg-1",
+        config_id="api.example.com",
+        api_id="api.example.com",
+        last_updated="2025-01-01T00:00:00Z",
+        handling_config={
+            "tracked_methods": ["GET /foo"],
+            "response_fields": [{"key": "value", "path": ""}],
+            "payload_mapping": {
+                "config": "config_identifier",
+                "timestamp": "timestamp",
+                "usage": "response_data.value",
+            },
+        },
+    )
+    monkeypatch.setattr(CostManagerConfig, "get_config", lambda self, api_id: [cfg])
+
+
+class DummyClientInit:
+    def __init__(self, *, aicm_api_key=None, aicm_api_base=None, aicm_api_url=None, aicm_ini_path=None, session=None, proxies=None, headers=None):
+        self.api_key = aicm_api_key
+        self.api_base = "http://x"
+        self.api_url = "/api"
+        self.session = session or DummySession()
+        self.ini_path = "ini"
+
+
+class DummyAsyncClientInit:
+    def __init__(self, *, aicm_api_key=None, aicm_api_base=None, aicm_api_url=None, aicm_ini_path=None, session=None, proxies=None, headers=None):
+        self.api_key = aicm_api_key
+        self.api_base = "http://x"
+        self.api_url = "/api"
+        self.session = session or DummyAsyncSession()
+        self.ini_path = "ini"
+
+
+def test_rest_manager_tracks(monkeypatch, config):
+    monkeypatch.setattr(CostManagerClient, "__init__", DummyClientInit.__init__)
+    session = DummySession()
+    manager = RestCostManager(session, base_url="https://api.example.com")
+    resp = manager.get("/foo")
+    assert resp.json() == {"value": 5}
+    payloads = manager.get_tracked_payloads()
+    assert len(payloads) == 1
+    assert payloads[0]["usage"] == 5
+
+
+def test_async_rest_manager_tracks(monkeypatch, config):
+    monkeypatch.setattr(AsyncCostManagerClient, "__init__", DummyAsyncClientInit.__init__)
+    monkeypatch.setattr(CostManagerClient, "__init__", DummyClientInit.__init__)
+
+    async def run():
+        session = DummyAsyncSession()
+        manager = AsyncRestCostManager(session, base_url="https://api.example.com")
+        resp = await manager.get("/foo")
+        assert resp.json() == {"value": 5}
+        payloads = manager.get_tracked_payloads()
+        assert len(payloads) == 1
+        assert payloads[0]["usage"] == 5
+        await manager.stop_delivery()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `RestCostManager` and `AsyncRestCostManager` for tracking plain REST APIs
- document usage and configuration
- expose new classes in the package
- mention REST tracking in docs
- test new wrappers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_688cdca98194832b8810ceac3383751e