### PR TITLE
feat: allow custom client metadata

### DIFF
--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Iterator, List, Optional
+from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 from .client import CostManagerClient, UsageLimitExceeded
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
@@ -30,6 +30,8 @@ class CostManager:
         aicm_api_base: Optional[str] = None,
         aicm_api_url: Optional[str] = None,
         aicm_ini_path: Optional[str] = None,
+        client_customer_key: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
         delivery: ResilientDelivery | None = None,
         delivery_queue_size: int = 1000,
         delivery_max_retries: int = 5,
@@ -48,6 +50,8 @@ class CostManager:
         self.extractor = UniversalExtractor(self.configs)
         self.tracked_payloads: list[dict[str, Any]] = []
         self.triggered_limits: List[TriggeredLimit] = []
+        self.client_customer_key = client_customer_key
+        self.context = context
 
         if delivery is not None:
             self.delivery = delivery
@@ -62,7 +66,9 @@ class CostManager:
     def _refresh_limits(self) -> None:
         """Load latest triggered limits from the config manager."""
         try:
-            self.triggered_limits = self.config_manager.get_triggered_limits()
+            self.triggered_limits = self.config_manager.get_triggered_limits(
+                client_customer_key=self.client_customer_key
+            )
             # Check for LIMIT threshold types that should block API calls
             blocking_limits = [
                 limit
@@ -77,6 +83,18 @@ class CostManager:
         except Exception:
             # Only catch other types of exceptions
             self.triggered_limits = []
+
+    def set_client_customer_key(self, client_customer_key: Optional[str]) -> None:
+        self.client_customer_key = client_customer_key
+
+    def set_context(self, context: Optional[Dict[str, Any]]) -> None:
+        self.context = context
+
+    def _augment_payload(self, payload: dict[str, Any]) -> None:
+        if self.client_customer_key and "client_customer_key" not in payload:
+            payload["client_customer_key"] = self.client_customer_key
+        if self.context and "context" not in payload:
+            payload["context"] = self.context
 
     # ------------------------------------------------------------
     # attribute proxying
@@ -107,6 +125,7 @@ class CostManager:
                 if payloads:
                     self.tracked_payloads.extend(payloads)
                     for payload in payloads:
+                        self._augment_payload(payload)
                         self.delivery.deliver({"usage_records": [payload]})
                 return response
 
@@ -286,6 +305,7 @@ class _StreamIterator:
         if payloads:
             self._manager.tracked_payloads.extend(payloads)
             for payload in payloads:
+                self._manager._augment_payload(payload)
                 self._manager.delivery.deliver({"usage_records": [payload]})
 
 
@@ -349,6 +369,7 @@ class _AsyncStreamIterator:
         if payloads:
             self._manager.tracked_payloads.extend(payloads)
             for payload in payloads:
+                self._manager._augment_payload(payload)
                 self._manager.delivery.deliver({"usage_records": [payload]})
 
 
@@ -394,6 +415,7 @@ class NestedAttributeWrapper:
                 if payloads:
                     self._parent_manager.tracked_payloads.extend(payloads)
                     for payload in payloads:
+                        self._parent_manager._augment_payload(payload)
                         self._parent_manager.delivery.deliver(
                             {"usage_records": [payload]}
                         )

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -97,6 +97,18 @@ class RestCostManager:
         except Exception:
             self.triggered_limits = []
 
+    def set_client_customer_key(self, client_customer_key: Optional[str]) -> None:
+        self.client_customer_key = client_customer_key
+
+    def set_context(self, context: Optional[Dict[str, Any]]) -> None:
+        self.context = context
+
+    def _augment_payload(self, payload: dict[str, Any]) -> None:
+        if self.client_customer_key and "client_customer_key" not in payload:
+            payload["client_customer_key"] = self.client_customer_key
+        if self.context and "context" not in payload:
+            payload["context"] = self.context
+
     def _full_url(self, url: str) -> str:
         if url.startswith("http"):
             return url
@@ -130,10 +142,7 @@ class RestCostManager:
         for payload in payloads:
             if "service_id" not in payload:
                 payload["service_id"] = service_id
-            if self.client_customer_key and "client_customer_key" not in payload:
-                payload["client_customer_key"] = self.client_customer_key
-            if self.context and "context" not in payload:
-                payload["context"] = self.context
+            self._augment_payload(payload)
         if payloads:
             self.tracked_payloads.extend(payloads)
             for p in payloads:
@@ -255,6 +264,18 @@ class AsyncRestCostManager:
         except Exception:
             self.triggered_limits = []
 
+    def set_client_customer_key(self, client_customer_key: Optional[str]) -> None:
+        self.client_customer_key = client_customer_key
+
+    def set_context(self, context: Optional[Dict[str, Any]]) -> None:
+        self.context = context
+
+    def _augment_payload(self, payload: dict[str, Any]) -> None:
+        if self.client_customer_key and "client_customer_key" not in payload:
+            payload["client_customer_key"] = self.client_customer_key
+        if self.context and "context" not in payload:
+            payload["context"] = self.context
+
     # main request ------------------------------------------------
     async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
         full = self._full_url(url)
@@ -277,10 +298,7 @@ class AsyncRestCostManager:
         for payload in payloads:
             if "service_id" not in payload:
                 payload["service_id"] = service_id
-            if self.client_customer_key and "client_customer_key" not in payload:
-                payload["client_customer_key"] = self.client_customer_key
-            if self.context and "context" not in payload:
-                payload["context"] = self.context
+            self._augment_payload(payload)
         if payloads:
             self.tracked_payloads.extend(payloads)
             for p in payloads:

--- a/tests/test_anthropic_real_cost_manager.py
+++ b/tests/test_anthropic_real_cost_manager.py
@@ -211,6 +211,8 @@ def test_anthropic_messages_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
     resp = tracked_client.messages.create(
         model="claude-3-haiku-20240307",
@@ -219,6 +221,8 @@ def test_anthropic_messages_usage_delivery(
     )
     event = verify_event_delivered(aicm_api_key, aicm_api_base, resp.id)
     assert event is not None
+    assert event.get("client_customer_key") == "test_client"
+    assert event.get("context", {}).get("foo") == "bar"
     assert "usage" in event
 
 
@@ -240,6 +244,8 @@ def test_anthropic_messages_streaming_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
     stream = tracked_client.messages.create(
         model="claude-3-haiku-20240307",
@@ -264,6 +270,8 @@ def test_anthropic_messages_streaming_usage_delivery(
     if response_id:
         event = verify_event_delivered(aicm_api_key, aicm_api_base, response_id)
         assert event is not None
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 

--- a/tests/test_async_cost_manager.py
+++ b/tests/test_async_cost_manager.py
@@ -172,3 +172,57 @@ def test_async_delivery(monkeypatch):
         assert session.calls[0][1]["usage_records"][0]["usage"] == 5
 
     asyncio.run(run())
+
+
+def test_async_client_customer_key_and_context(monkeypatch):
+    cfg = Config(
+        uuid="cfg-1",
+        config_id="dummy",
+        api_id="dummyclient",
+        last_updated="2025-01-01T00:00:00Z",
+        handling_config={
+            "tracked_methods": ["add"],
+            "request_fields": ["a", "b"],
+            "response_fields": [{"key": "value", "path": ""}],
+            "payload_mapping": {
+                "config": "config_identifier",
+                "timestamp": "timestamp",
+                "usage": "response_data.value",
+            },
+        },
+    )
+    monkeypatch.setattr(CostManagerConfig, "get_config", lambda self, api_id: [cfg])
+
+    def fake_async_init(self, *, aicm_api_key=None, aicm_api_base=None, aicm_api_url=None, aicm_ini_path=None, session=None):
+        self.api_key = aicm_api_key
+        self.api_base = "http://x"
+        self.api_url = "/api"
+        self.session = session or DummySession()
+        self.ini_path = "ini"
+
+    def fake_sync_init(self, *, aicm_api_key=None, aicm_api_base=None, aicm_api_url=None, aicm_ini_path=None, session=None, proxies=None, headers=None):
+        self.api_key = aicm_api_key
+        self.api_base = "http://x"
+        self.api_url = "/api"
+        self.session = session or DummySession()
+        self.ini_path = "ini"
+
+    monkeypatch.setattr(AsyncCostManagerClient, "__init__", fake_async_init)
+    monkeypatch.setattr(CostManagerClient, "__init__", fake_sync_init)
+
+    async def run():
+        manager = AsyncCostManager(
+            DummyClient(), client_customer_key="c1", context={"foo": "bar"}
+        )
+        await manager.add(a=1, b=2)
+        manager.set_client_customer_key("c2")
+        manager.set_context({"baz": "qux"})
+        await manager.add(a=2, b=3)
+        payloads = manager.get_tracked_payloads()
+        assert payloads[0]["client_customer_key"] == "c1"
+        assert payloads[0]["context"] == {"foo": "bar"}
+        assert payloads[1]["client_customer_key"] == "c2"
+        assert payloads[1]["context"] == {"baz": "qux"}
+        await manager.stop_delivery()
+
+    asyncio.run(run())

--- a/tests/test_bedrock_real_cost_manager.py
+++ b/tests/test_bedrock_real_cost_manager.py
@@ -207,6 +207,8 @@ def test_bedrock_converse_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     response = tracked_client.converse(
@@ -232,6 +234,8 @@ def test_bedrock_converse_usage_delivery(
         assert event is not None, (
             f"Usage event for response_id {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 
@@ -250,6 +254,8 @@ def test_bedrock_converse_streaming_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -288,6 +294,8 @@ def test_bedrock_converse_streaming_usage_delivery(
         assert event is not None, (
             f"Streaming usage event for response_id {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 

--- a/tests/test_cost_manager.py
+++ b/tests/test_cost_manager.py
@@ -63,3 +63,36 @@ def test_context_manager(monkeypatch):
         assert m is manager
     assert calls["start"] == 1
     assert calls["stop"] == 1
+
+
+def test_client_customer_key_and_context(monkeypatch):
+    cfg = Config(
+        uuid="cfg-1",
+        config_id="dummy",
+        api_id="dummyclient",
+        last_updated="2025-01-01T00:00:00Z",
+        handling_config={
+            "tracked_methods": ["add"],
+            "request_fields": ["a", "b"],
+            "response_fields": [{"key": "value", "path": ""}],
+            "payload_mapping": {
+                "config": "config_identifier",
+                "timestamp": "timestamp",
+                "usage": "response_data.value",
+            },
+        },
+    )
+    monkeypatch.setattr(CostManagerConfig, "get_config", lambda self, api_id: [cfg])
+
+    manager = CostManager(
+        DummyClient(), client_customer_key="c1", context={"foo": "bar"}
+    )
+    manager.add(a=1, b=2)
+    manager.set_client_customer_key("c2")
+    manager.set_context({"baz": "qux"})
+    manager.add(a=2, b=3)
+    payloads = manager.get_tracked_payloads()
+    assert payloads[0]["client_customer_key"] == "c1"
+    assert payloads[0]["context"] == {"foo": "bar"}
+    assert payloads[1]["client_customer_key"] == "c2"
+    assert payloads[1]["context"] == {"baz": "qux"}

--- a/tests/test_gemini_real_cost_manager.py
+++ b/tests/test_gemini_real_cost_manager.py
@@ -207,6 +207,8 @@ def test_gemini_generate_content_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -250,6 +252,8 @@ def test_gemini_generate_content_usage_delivery(
         assert event is not None, (
             f"Usage event {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 
@@ -268,6 +272,8 @@ def test_gemini_generate_content_streaming_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -315,6 +321,8 @@ def test_gemini_generate_content_streaming_usage_delivery(
         assert event is not None, (
             f"Streaming usage event {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 

--- a/tests/test_openai_compatible_real_cost_manager.py
+++ b/tests/test_openai_compatible_real_cost_manager.py
@@ -206,6 +206,8 @@ def test_deepseek_openai_chat_completion_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -243,6 +245,8 @@ def test_deepseek_openai_chat_completion_usage_delivery(
         assert event is not None, (
             f"Usage event {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 
@@ -261,6 +265,8 @@ def test_deepseek_openai_chat_completion_streaming_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -305,6 +311,8 @@ def test_deepseek_openai_chat_completion_streaming_usage_delivery(
         assert event is not None, (
             f"Streaming usage event {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 
@@ -412,6 +420,8 @@ def test_gemini_openai_chat_completion_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -449,6 +459,8 @@ def test_gemini_openai_chat_completion_usage_delivery(
         assert event is not None, (
             f"Usage event {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 
@@ -467,6 +479,8 @@ def test_gemini_openai_chat_completion_streaming_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Refresh config to pick up server changes
@@ -511,6 +525,8 @@ def test_gemini_openai_chat_completion_streaming_usage_delivery(
         assert event is not None, (
             f"Streaming usage event {response_id} was not delivered to server"
         )
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
 
 

--- a/tests/test_openai_real_cost_manager.py
+++ b/tests/test_openai_real_cost_manager.py
@@ -486,6 +486,8 @@ def test_openai_chat_completion_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Make a test API call that should trigger automatic usage delivery
@@ -511,6 +513,8 @@ def test_openai_chat_completion_usage_delivery(
         assert event.get("config_id") == "openai_chat"
         assert event.get("service_id") == response.model
         assert event.get("response_id") == response.id
+        assert event.get("client_customer_key") == "test_client"
+        assert event.get("context", {}).get("foo") == "bar"
         assert "usage" in event
         assert "timestamp" in event
 
@@ -535,6 +539,8 @@ def test_openai_chat_completion_streaming_usage_delivery(
         aicm_api_key=aicm_api_key,
         aicm_api_base=aicm_api_base,
         aicm_ini_path=aicm_ini_path,
+        client_customer_key="test_client",
+        context={"foo": "bar"},
     )
 
     # Test streaming chat completion API
@@ -585,6 +591,8 @@ def test_openai_chat_completion_streaming_usage_delivery(
             # Verify event structure
             assert event.get("config_id") == "openai_chat"
             assert event.get("response_id") == response_id
+            assert event.get("client_customer_key") == "test_client"
+            assert event.get("context", {}).get("foo") == "bar"
             assert "usage" in event
             assert "timestamp" in event
 


### PR DESCRIPTION
## Summary
- allow all cost manager variants to include optional client_customer_key and context metadata
- support updating these fields after initialization and add to tracked payloads
- add tests for new metadata capabilities

## Testing
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6890bc8a1230832bb06d8d6f04291c9d