### PR TITLE
feat: add async delivery mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,13 @@ tracked_client = CostManager(
     delivery_queue_size=1000,      # Queue size for batching
     delivery_max_retries=5,        # Retry failed deliveries
     delivery_timeout=10.0,         # Request timeout in seconds
+    # delivery_mode="async",       # Use async delivery (or set AICM_DELIVERY_MODE)
 )
 ```
+
+Set the environment variable ``AICM_DELIVERY_MODE=async`` (or pass
+``delivery_mode="async"`` as shown above) to use an ``httpx.AsyncClient`` with
+non-blocking retries—ideal for eventlet/gevent worker pools.
 
 When using process-based workers such as Celery or the ``multiprocessing``
 module, create the ``CostManager`` inside the worker's initialisation hook.

--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -36,6 +36,7 @@ class CostManager:
         delivery_queue_size: int = 1000,
         delivery_max_retries: int = 5,
         delivery_timeout: float = 10.0,
+        delivery_mode: str | None = None,
     ) -> None:
         self.client = client
         self.cm_client = CostManagerClient(
@@ -61,6 +62,7 @@ class CostManager:
                 max_retries=delivery_max_retries,
                 queue_size=delivery_queue_size,
                 timeout=delivery_timeout,
+                delivery_mode=delivery_mode,
             )
 
     def _refresh_limits(self) -> None:

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -48,6 +48,7 @@ class RestCostManager:
         delivery_queue_size: int = 1000,
         delivery_max_retries: int = 5,
         delivery_timeout: float = 10.0,
+        delivery_mode: str | None = None,
     ) -> None:
         self.session = session or requests.Session()
         self.base_url = base_url.rstrip("/")
@@ -79,6 +80,7 @@ class RestCostManager:
                 max_retries=delivery_max_retries,
                 queue_size=delivery_queue_size,
                 timeout=delivery_timeout,
+                delivery_mode=delivery_mode,
             )
 
     # ------------------------------------------------------------

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -60,6 +60,19 @@ application.  The queue size and retry policy can be tuned via
 ``/track-usage`` URL.  Payloads added to the queue are batched whenever
 possible and sent with a configurable timeout (default 10 seconds).
 
+## Selecting Delivery Mode
+
+``ResilientDelivery`` supports two modes:
+
+* **sync** (default) – uses a standard ``requests`` session.
+* **async** – performs delivery using ``httpx.AsyncClient`` together with
+  ``tenacity.AsyncRetrying`` for non-blocking retries.
+
+Set ``AICM_DELIVERY_MODE=async`` (or pass ``delivery_mode="async"`` when
+constructing ``CostManager``/``RestCostManager``) to enable the async mode.
+This is useful for eventlet or gevent worker pools where blocking network
+operations should be avoided.
+
 An asynchronous variant ``AsyncCostManager`` is available for wrapping
 async API clients.  It behaves the same as ``CostManager`` but uses an
 ``asyncio`` delivery queue and ``AsyncCostManagerClient`` for network


### PR DESCRIPTION
## Summary
- support configurable async delivery using httpx and AsyncRetrying
- allow CostManager and RestCostManager to select sync or async delivery
- document delivery mode selection and add async delivery test

## Testing
- `pytest tests/test_delivery.py::test_async_delivery_retries_success -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6891ec2d4cbc832b88d593ddff5ff04e