### PR TITLE
Add configurable queue-full behaviour with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ tracked_client = CostManager(
     delivery_max_retries=5,        # Retry failed deliveries
     delivery_timeout=10.0,         # Request timeout in seconds
     # delivery_mode="async",       # Use async delivery (or set AICM_DELIVERY_MODE)
+    # delivery_on_full="backpressure",  # Block, raise, or backpressure when full
 )
 ```
 
@@ -272,6 +273,7 @@ tracked_client = CostManager(
     aicm_api_base="https://custom.url",    # Custom API base
     delivery_queue_size=2000,              # Larger queue
     delivery_max_retries=10,               # More retries
+    delivery_on_full="raise",             # Block, raise, or backpressure
 )
 ```
 

--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -37,6 +37,7 @@ class CostManager:
         delivery_max_retries: int = 5,
         delivery_timeout: float = 10.0,
         delivery_mode: str | None = None,
+        delivery_on_full: str = "backpressure",
     ) -> None:
         self.client = client
         self.cm_client = CostManagerClient(
@@ -63,6 +64,7 @@ class CostManager:
                 queue_size=delivery_queue_size,
                 timeout=delivery_timeout,
                 delivery_mode=delivery_mode,
+                on_full=delivery_on_full,
             )
 
     def _refresh_limits(self) -> None:

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -49,6 +49,7 @@ class RestCostManager:
         delivery_max_retries: int = 5,
         delivery_timeout: float = 10.0,
         delivery_mode: str | None = None,
+        delivery_on_full: str = "backpressure",
     ) -> None:
         self.session = session or requests.Session()
         self.base_url = base_url.rstrip("/")
@@ -81,6 +82,7 @@ class RestCostManager:
                 queue_size=delivery_queue_size,
                 timeout=delivery_timeout,
                 delivery_mode=delivery_mode,
+                on_full=delivery_on_full,
             )
 
     # ------------------------------------------------------------

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -54,7 +54,10 @@ The implementation focuses on reliability rather than throughput.
 Payloads are sent via a background thread with a bounded queue so that
 usage tracking will not exhaust memory when used inside a web
 application.  The queue size and retry policy can be tuned via
-``CostManager`` parameters.
+``CostManager`` parameters. When the queue is full the default behaviour
+is to drop the oldest payload and log a warning. Set
+``delivery_on_full`` to ``"block"`` to wait for space or ``"raise"`` to
+propagate ``queue.Full`` back to the caller.
 
 ``ResilientDelivery`` uses the client's ``api_root`` to construct the
 ``/track-usage`` URL.  Payloads added to the queue are batched whenever


### PR DESCRIPTION
## Summary
- log a warning when the delivery queue is full
- allow choosing to block, raise, or apply backpressure via `delivery_on_full`
- document queue-full behaviour and add regression tests

## Testing
- `AICM_API_KEY=sk-test pytest tests/test_delivery.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6891eefdeecc832b8ea8066c506afbf4