### PR TITLE
Add manual usage tracker

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -18,6 +18,7 @@ from .delivery import (
     get_global_delivery,
     get_global_delivery_health,
 )
+from .tracker import Tracker, UsageValidationError
 from .models import (
     ApiUsageRecord,
     ApiUsageRequest,
@@ -62,6 +63,8 @@ __all__ = [
     "ResilientDelivery",
     "get_global_delivery",
     "get_global_delivery_health",
+    "Tracker",
+    "UsageValidationError",
     "ApiUsageRecord",
     "ApiUsageRequest",
     "ApiUsageResponse",

--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from .client import CostManagerClient
+from .config_manager import Config, CostManagerConfig
+from .delivery import ResilientDelivery, get_global_delivery
+from .type_validator import TypeValidator
+
+
+class UsageValidationError(ValueError):
+    """Raised when supplied usage data fails schema validation."""
+
+    def __init__(
+        self,
+        errors: Dict[str, str] | None = None,
+        missing_fields: list[str] | None = None,
+        extra_fields: list[str] | None = None,
+    ) -> None:
+        errors = errors or {}
+        missing_fields = missing_fields or []
+        extra_fields = extra_fields or []
+        messages = []
+        if missing_fields:
+            messages.append(f"Missing fields: {', '.join(missing_fields)}")
+        if errors:
+            messages.append(
+                "Type errors: "
+                + "; ".join(f"{field}: {msg}" for field, msg in errors.items())
+            )
+        if extra_fields:
+            messages.append(f"Unexpected fields: {', '.join(extra_fields)}")
+        super().__init__("; ".join(messages))
+        self.errors = errors
+        self.missing_fields = missing_fields
+        self.extra_fields = extra_fields
+
+
+class Tracker:
+    """Manually track usage for a given configuration and service."""
+
+    def __init__(
+        self,
+        config_id: str,
+        service_id: str,
+        *,
+        aicm_api_key: Optional[str] = None,
+        aicm_api_base: Optional[str] = None,
+        aicm_api_url: Optional[str] = None,
+        aicm_ini_path: Optional[str] = None,
+        delivery: ResilientDelivery | None = None,
+        delivery_queue_size: int = 1000,
+        delivery_max_retries: int = 5,
+        delivery_timeout: float = 10.0,
+        delivery_batch_interval: float | None = None,
+        delivery_max_batch_size: int = 100,
+        delivery_mode: str | None = None,
+        delivery_on_full: str = "backpressure",
+    ) -> None:
+        self.config_id = config_id
+        self.service_id = service_id
+        self.cm_client = CostManagerClient(
+            aicm_api_key=aicm_api_key,
+            aicm_api_base=aicm_api_base,
+            aicm_api_url=aicm_api_url,
+            aicm_ini_path=aicm_ini_path,
+        )
+        self.config_manager = CostManagerConfig(self.cm_client)
+        cfg: Config = self.config_manager.get_config_by_id(config_id)
+        self.manual_usage_schema: Dict[str, str] = cfg.manual_usage_schema or {}
+        self._validator = TypeValidator()
+        if delivery is not None:
+            self.delivery = delivery
+        else:
+            self.delivery = get_global_delivery(
+                self.cm_client,
+                max_retries=delivery_max_retries,
+                queue_size=delivery_queue_size,
+                timeout=delivery_timeout,
+                batch_interval=delivery_batch_interval,
+                max_batch_size=delivery_max_batch_size,
+                delivery_mode=delivery_mode,
+                on_full=delivery_on_full,
+            )
+
+    def track(
+        self,
+        usage: Dict[str, Any],
+        *,
+        client_customer_key: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Validate and deliver a usage record."""
+        if self.manual_usage_schema:
+            errors: Dict[str, str] = {}
+            missing: list[str] = []
+            for field, type_str in self.manual_usage_schema.items():
+                if field not in usage:
+                    if "Optional" not in type_str:
+                        missing.append(field)
+                    continue
+                is_valid, err = self._validator.validate_value(usage[field], type_str)
+                if not is_valid:
+                    errors[field] = err
+            extra = [f for f in usage if f not in self.manual_usage_schema]
+            if errors or missing or extra:
+                raise UsageValidationError(errors, missing, extra)
+
+        record: Dict[str, Any] = {
+            "config_id": self.config_id,
+            "service_id": self.service_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "response_id": uuid4().hex,
+            "usage": usage,
+        }
+        if client_customer_key is not None:
+            record["client_customer_key"] = client_customer_key
+        if context is not None:
+            record["context"] = context
+
+        self.delivery.deliver({"usage_records": [record]})

--- a/aicostmanager/type_validator.py
+++ b/aicostmanager/type_validator.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+import re
+
+
+class TypeValidator:
+    """Validate values against string-specified Python type hints."""
+
+    def __init__(self) -> None:
+        self.basic_types = {
+            "int": int,
+            "float": float,
+            "str": str,
+            "bool": bool,
+            "list": list,
+            "dict": dict,
+            "tuple": tuple,
+            "set": set,
+        }
+        self.pattern_validators = {
+            r"List\[(\w+)\]": self._validate_typed_list,
+            r"Dict\[(\w+),\s*(\w+)\]": self._validate_typed_dict,
+            r"Optional\[(\w+)\]": self._validate_optional,
+            r"Union\[(.+)\]": self._validate_union,
+        }
+
+    def validate_value(self, value: Any, type_string: str) -> Tuple[bool, str]:
+        """Validate a value against a type string."""
+        try:
+            if value is None:
+                if "Optional" in type_string or "Union" in type_string:
+                    return True, ""
+                return False, f"Value cannot be None for type {type_string}"
+
+            if type_string in self.basic_types:
+                expected = self.basic_types[type_string]
+                if isinstance(value, expected):
+                    return True, ""
+                return False, f"Expected {type_string}, got {type(value).__name__}"
+
+            for pattern, validator in self.pattern_validators.items():
+                match = re.match(pattern, type_string)
+                if match:
+                    return validator(value, match.groups())
+
+            return False, f"Unsupported type string: {type_string}"
+        except Exception as exc:
+            return False, f"Validation error: {exc}"
+
+    # --- pattern handlers -------------------------------------------------
+    def _validate_typed_list(self, value: Any, groups: Tuple[str, ...]) -> Tuple[bool, str]:
+        if not isinstance(value, list):
+            return False, f"Expected list, got {type(value).__name__}"
+        element = groups[0]
+        expected = self.basic_types.get(element)
+        if expected:
+            for idx, item in enumerate(value):
+                if not isinstance(item, expected):
+                    return False, f"List element at index {idx} is {type(item).__name__}, expected {element}"
+        return True, ""
+
+    def _validate_typed_dict(self, value: Any, groups: Tuple[str, ...]) -> Tuple[bool, str]:
+        if not isinstance(value, dict):
+            return False, f"Expected dict, got {type(value).__name__}"
+        key_type, value_type = groups
+        key_cls = self.basic_types.get(key_type)
+        value_cls = self.basic_types.get(value_type)
+        if key_cls and value_cls:
+            for k, v in value.items():
+                if not isinstance(k, key_cls):
+                    return False, f"Dict key {k} is {type(k).__name__}, expected {key_type}"
+                if not isinstance(v, value_cls):
+                    return False, f"Dict value for key '{k}' is {type(v).__name__}, expected {value_type}"
+        return True, ""
+
+    def _validate_optional(self, value: Any, groups: Tuple[str, ...]) -> Tuple[bool, str]:
+        inner = groups[0]
+        if value is None:
+            return True, ""
+        return self.validate_value(value, inner)
+
+    def _validate_union(self, value: Any, groups: Tuple[str, ...]) -> Tuple[bool, str]:
+        options = [t.strip() for t in groups[0].split(",")]
+        for option in options:
+            ok, _ = self.validate_value(value, option)
+            if ok:
+                return True, ""
+        return False, f"Value doesn't match any type in Union[{groups[0]}]"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,56 @@
+import pytest
+
+from aicostmanager.config_manager import Config, CostManagerConfig
+from aicostmanager.tracker import Tracker, UsageValidationError
+
+
+class DummyDelivery:
+    def __init__(self):
+        self.payloads = []
+
+    def deliver(self, payload):
+        self.payloads.append(payload)
+
+
+def test_tracker_valid_usage(monkeypatch):
+    cfg = Config(
+        uuid="u",
+        config_id="cfg",
+        api_id="api",
+        last_updated="now",
+        handling_config={},
+        manual_usage_schema={"tokens": "int", "model": "str"},
+    )
+
+    def fake_get_config_by_id(self, config_id):
+        return cfg
+
+    monkeypatch.setattr(CostManagerConfig, "get_config_by_id", fake_get_config_by_id)
+    delivery = DummyDelivery()
+    tracker = Tracker("cfg", "svc", aicm_api_key="sk-test", delivery=delivery)
+
+    tracker.track({"tokens": 10, "model": "gpt"})
+    assert len(delivery.payloads) == 1
+    record = delivery.payloads[0]["usage_records"][0]
+    assert record["usage"]["tokens"] == 10
+    assert record["service_id"] == "svc"
+
+
+def test_tracker_invalid_usage(monkeypatch):
+    cfg = Config(
+        uuid="u",
+        config_id="cfg",
+        api_id="api",
+        last_updated="now",
+        handling_config={},
+        manual_usage_schema={"tokens": "int"},
+    )
+
+    def fake_get_config_by_id(self, config_id):
+        return cfg
+
+    monkeypatch.setattr(CostManagerConfig, "get_config_by_id", fake_get_config_by_id)
+    tracker = Tracker("cfg", "svc", aicm_api_key="sk-test", delivery=DummyDelivery())
+
+    with pytest.raises(UsageValidationError):
+        tracker.track({"tokens": "wrong"})

--- a/tests/test_type_validator.py
+++ b/tests/test_type_validator.py
@@ -1,0 +1,48 @@
+import pytest
+
+from aicostmanager.type_validator import TypeValidator
+
+
+def test_basic_type_validation():
+    validator = TypeValidator()
+    assert validator.validate_value(1, "int")[0]
+    ok, msg = validator.validate_value("1", "int")
+    assert not ok
+    assert "Expected int" in msg
+
+
+def test_typed_list_validation():
+    validator = TypeValidator()
+    assert validator.validate_value([1, 2, 3], "List[int]")[0]
+    ok, msg = validator.validate_value([1, "2"], "List[int]")
+    assert not ok
+    assert "List element at index 1" in msg
+
+
+def test_typed_dict_validation():
+    validator = TypeValidator()
+    assert validator.validate_value({"a": 1}, "Dict[str, int]")[0]
+    ok, msg = validator.validate_value({1: 1}, "Dict[str, int]")
+    assert not ok
+    assert "Dict key 1 is int" in msg
+
+
+def test_optional_and_union_validation():
+    validator = TypeValidator()
+    assert validator.validate_value(None, "Optional[int]")[0]
+    assert validator.validate_value(5, "Optional[int]")[0]
+    ok, msg = validator.validate_value("5", "Optional[int]")
+    assert not ok
+    assert "Expected int" in msg
+
+    assert validator.validate_value("abc", "Union[int, str]")[0]
+    ok, msg = validator.validate_value(1.5, "Union[int, str]")
+    assert not ok
+    assert "Union" in msg
+
+
+def test_unsupported_type_string():
+    validator = TypeValidator()
+    ok, msg = validator.validate_value(1, "UnknownType")
+    assert not ok
+    assert "Unsupported type string" in msg


### PR DESCRIPTION
## Summary
- expand Config model to include optional manual usage schemas and retrieval by config_id
- add TypeValidator and Tracker classes for manual usage tracking with validation
- cover manual tracking behavior with unit tests
- add pytest coverage for TypeValidator covering primitives, collections, optional/union, and unsupported types

## Testing
- `pip install pydantic httpx requests PyJWT tenacity cryptography` *(fails: Could not find a version that satisfies the requirement pydantic; ProxyError Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_type_validator.py::test_basic_type_validation -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_6894a2b5c598832b9276a0d68a1a7cf9