### PR TITLE
feat: expose delivery overflow options and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,17 @@ tracked_client = CostManager(
     delivery_batch_interval=0.05,  # Wait up to 50ms for more items
     delivery_max_batch_size=100,   # Flush when batch reaches this size
     # delivery_mode="async",       # Use async delivery (or set AICM_DELIVERY_MODE)
-    # delivery_on_full="backpressure",  # Block, raise, or backpressure when full
+    # delivery_on_full="backpressure",  # Block, raise, or backpressure when full (or set AICM_DELIVERY_ON_FULL)
 )
 ```
 
 Set the environment variable ``AICM_DELIVERY_MODE=async`` (or pass
 ``delivery_mode="async"`` as shown above) to use an ``httpx.AsyncClient`` with
 non-blocking retries—ideal for eventlet/gevent worker pools.
+
+To change the default behaviour when the queue is full, set
+``AICM_DELIVERY_ON_FULL`` to ``block`` or ``raise``.  The default is
+``backpressure`` which discards the oldest payload.
 
 When using process-based workers such as Celery or the ``multiprocessing``
 module, create the ``CostManager`` inside the worker's initialisation hook.

--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -39,7 +39,7 @@ class CostManager:
         delivery_batch_interval: float | None = None,
         delivery_max_batch_size: int = 100,
         delivery_mode: str | None = None,
-        delivery_on_full: str = "backpressure",
+        delivery_on_full: str | None = None,
     ) -> None:
         self.client = client
         self.cm_client = CostManagerClient(

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -51,7 +51,7 @@ class RestCostManager:
         delivery_batch_interval: float | None = None,
         delivery_max_batch_size: int = 100,
         delivery_mode: str | None = None,
-        delivery_on_full: str = "backpressure",
+        delivery_on_full: str | None = None,
     ) -> None:
         self.session = session or requests.Session()
         self.base_url = base_url.rstrip("/")

--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -58,7 +58,7 @@ class Tracker:
         delivery_batch_interval: float | None = None,
         delivery_max_batch_size: int = 100,
         delivery_mode: str | None = None,
-        delivery_on_full: str = "backpressure",
+        delivery_on_full: str | None = None,
     ) -> None:
         self.config_id = config_id
         self.service_id = service_id
@@ -103,7 +103,7 @@ class Tracker:
         delivery_batch_interval: float | None = None,
         delivery_max_batch_size: int = 100,
         delivery_mode: str | None = None,
-        delivery_on_full: str = "backpressure",
+        delivery_on_full: str | None = None,
     ) -> "Tracker":
         """Asynchronously create a fully initialized :class:`Tracker`.
 

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -57,7 +57,9 @@ application.  The queue size and retry policy can be tuned via
 ``CostManager`` parameters. When the queue is full the default behaviour
 is to drop the oldest payload and log a warning. Set
 ``delivery_on_full`` to ``"block"`` to wait for space or ``"raise"`` to
-propagate ``queue.Full`` back to the caller.
+propagate ``queue.Full`` back to the caller.  You can also set the
+environment variable ``AICM_DELIVERY_ON_FULL`` to control this default
+globally.
 
 ``ResilientDelivery`` uses the client's ``api_root`` to construct the
 ``/track-usage`` URL.  The worker waits a short configurable window


### PR DESCRIPTION
## Summary
- emit discard metrics and optional callback when the delivery queue drops payloads
- allow configuring queue overflow behavior via `AICM_DELIVERY_ON_FULL`
- document and test new delivery overflow controls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests httpx pydantic PyJWT -q` *(fails: Could not find a version that satisfies the requirement requests)*
- `AICM_API_KEY=sk pytest tests/test_delivery.py::test_discard_callback_and_metrics tests/test_delivery.py::test_env_on_full -q`


------
https://chatgpt.com/codex/tasks/task_b_6894ed657bb0832bb7d245345c3278ae