### PR TITLE
docs: add manual tracker documentation and cross references

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ def get_recent_usage(aicm_api_key: str, customer_id: str = None):
 - **[🏢 Multi-Tenant Guide](docs/multi-tenant.md)** - Client tracking, cost allocation, and billing
 - **[📊 Usage Examples](docs/usage.md)** - API usage and basic examples
 - **[🔧 Tracking System](docs/tracking.md)** - How the tracking system works
+- **[📐 Manual Usage Tracking](docs/tracker.md)** - Record custom usage events
+- **[🌐 REST API Tracking](docs/rest.md)** - Wrap requests or httpx sessions
 - **[🧪 Testing Guide](docs/testing.md)** - Running tests and validation
 
 ### Quick Reference
@@ -325,6 +327,8 @@ def get_recent_usage(aicm_api_key: str, customer_id: str = None):
 | **Multi-Tenant** | Track costs per client, project, or department | [Guide](docs/multi-tenant.md) |
 | **Basic Usage** | SDK installation and simple examples | [Usage](docs/usage.md) |
 | **Tracking** | How usage tracking works under the hood | [Tracking](docs/tracking.md) |
+| **Manual Tracking** | Send custom usage records without wrappers | [Tracker](docs/tracker.md) |
+| **REST API** | Track raw HTTP requests | [REST Tracking](docs/rest.md) |
 | **Testing** | Running tests and validation | [Testing](docs/testing.md) |
 
 ### API Reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 - **[Multi-Tenant & Client Tracking](multi-tenant.md)** - Track costs across multiple clients, projects, and departments
 - [Usage](usage.md) - Basic SDK usage and API examples
 - [Tracking](tracking.md) - How the tracking system works
+- [Manual Usage Tracking](tracker.md) - Record custom usage events
 - [REST API Tracking](rest.md) - Wrap requests or httpx sessions
 
 ## Development

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -1,0 +1,80 @@
+# Manual Usage Tracking with `Tracker`
+
+`Tracker` lets you send usage records directly to AICostManager when you
+cannot or do not want to wrap an API client with `CostManager`.
+It loads a manual usage schema from the service configuration to validate
+payloads before delivery.
+
+## Creating a Tracker
+
+```python
+from aicostmanager import Tracker
+
+tracker = Tracker("cfg", "svc")
+```
+
+* ``cfg`` – configuration identifier returned from ``/configs``
+* ``svc`` – the service identifier your usage belongs to
+
+The tracker automatically loads the manual usage schema for the given
+configuration.  If the schema declares required fields or types they will be
+validated when calling :meth:`track`.
+
+### Asynchronous factory
+
+Configuration loading uses blocking I/O.  In async applications use the
+factory to perform the setup in a thread:
+
+```python
+tracker = await Tracker.create_async("cfg", "svc")
+```
+
+The returned instance is ready to use inside your async code.
+
+## Recording Usage
+
+```python
+usage = {"tokens": 10, "model": "gpt"}
+tracker.track(usage, client_customer_key="cust1", context={"task": "demo"})
+```
+
+``client_customer_key`` associates the record with one of your customers and
+``context`` allows attaching arbitrary metadata.  The tracker builds the payload
+and queues it for background delivery.
+
+If the usage dictionary does not match the schema a
+:class:`UsageValidationError` is raised detailing the missing or invalid fields.
+
+## Stopping the delivery worker
+
+The tracker shares the global delivery worker by default.  To shut it down
+cleanly, call ``close`` during application shutdown:
+
+```python
+tracker.close()
+```
+
+## FastAPI example
+
+```python
+from fastapi import FastAPI
+from aicostmanager import Tracker
+
+app = FastAPI()
+
+@app.on_event("startup")
+async def startup() -> None:
+    app.state.tracker = await Tracker.create_async("cfg", "svc")
+
+@app.on_event("shutdown")
+def shutdown() -> None:
+    app.state.tracker.close()
+
+@app.post("/track")
+async def track_usage(payload: dict) -> dict:
+    app.state.tracker.track(payload)
+    return {"status": "ok"}
+```
+
+The tracker instance is created once at startup, re-used for incoming requests
+and closed when the application exits.

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -1,5 +1,7 @@
 # Tracking Usage with `CostManager`
 
+For manual tracking without wrapping an API client, see [Manual Usage Tracking](tracker.md).
+
 `CostManager` provides a small wrapper around any API client so that the
 client's activity can be analysed.  It relies on configuration returned
 from `CostManagerConfig` which describes how requests and responses

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,6 +81,8 @@ async def async_example():
 
 ## FastAPI integration
 
+See [Manual Usage Tracking](tracker.md) for a detailed guide on using the Tracker class.
+
 When recording custom usage with :class:`Tracker` in a FastAPI application,
 create the tracker during application startup so configuration loading doesn't
 block individual requests. The asynchronous factory ``Tracker.create_async``


### PR DESCRIPTION
## Summary
- document manual usage tracking with the new `Tracker` class
- cross-link tracker docs from README, index, and usage guides
- mention manual tracking from automatic tracking guide

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6895099ac484832ba54beaa4b063236a