### PR TITLE
feat: allow overriding response id in tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ tracker.track({
     "model": "gpt-4o-mini",
 })
 
+# Reuse a session or request identifier from the upstream service
+# tracker.track({"tokens": 123, "model": "gpt-4o-mini"}, response_id="session123")
+
 # Async initialization for web apps
 # tracker = await Tracker.create_async("cfg", "svc")
 # tracker.close()  # during shutdown

--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -134,10 +134,24 @@ class Tracker:
         self,
         usage: Dict[str, Any],
         *,
+        response_id: Optional[str] = None,
         client_customer_key: Optional[str] = None,
         context: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Validate and deliver a usage record."""
+        """Validate and deliver a usage record.
+
+        Parameters
+        ----------
+        usage:
+            The usage payload to validate and send.
+        response_id:
+            Optional identifier to associate with the usage record. If not
+            provided a random UUID4 hex string is generated.
+        client_customer_key:
+            Optional identifier for grouping usage by customer.
+        context:
+            Optional additional metadata to include with the record.
+        """
         if self.manual_usage_schema:
             errors: Dict[str, str] = {}
             missing: list[str] = []
@@ -157,7 +171,7 @@ class Tracker:
             "config_id": self.config_id,
             "service_id": self.service_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "response_id": uuid4().hex,
+            "response_id": response_id or uuid4().hex,
             "usage": usage,
         }
         if client_customer_key is not None:

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -55,6 +55,16 @@ tracker.track(
 )
 ```
 
+## Custom Response IDs
+
+If the API you are tracking provides its own session or request identifier,
+you can use it for the usage record's ``response_id``:
+
+```python
+session_id = remote_response["session_id"]
+tracker.track({"duration": 12.3}, response_id=session_id)
+```
+
 ## Async Initialization (Web Apps)
 
 ```python

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -46,6 +46,28 @@ def test_tracker_valid_usage(monkeypatch):
     assert record["service_id"] == "svc"
 
 
+def test_tracker_custom_response_id(monkeypatch):
+    cfg = Config(
+        uuid="u",
+        config_id="cfg",
+        api_id="api",
+        last_updated="now",
+        handling_config={},
+        manual_usage_schema={"tokens": "int", "model": "str"},
+    )
+
+    def fake_get_config_by_id(self, config_id):
+        return cfg
+
+    monkeypatch.setattr(CostManagerConfig, "get_config_by_id", fake_get_config_by_id)
+    delivery = DummyDelivery()
+    tracker = Tracker("cfg", "svc", aicm_api_key="sk-test", delivery=delivery)
+
+    tracker.track({"tokens": 10, "model": "gpt"}, response_id="session123")
+    record = delivery.payloads[0]["usage_records"][0]
+    assert record["response_id"] == "session123"
+
+
 def test_tracker_invalid_usage(monkeypatch):
     cfg = Config(
         uuid="u",


### PR DESCRIPTION
## Summary
- allow overriding the auto-generated response_id when tracking manual usage
- document custom response IDs and update tracker documentation
- test Tracker.track with a supplied response_id

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -q requests httpx PyJWT anthropic boto3 google-genai openai` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_b_689917e06374832ba73f8dd17875faf8