### PR TITLE
Switch HeyGen sync example to Tracker.track

### DIFF
--- a/examples/heygen_sync.py
+++ b/examples/heygen_sync.py
@@ -2,17 +2,17 @@
 
 """Sync HeyGen streaming sessions to AICostManager.
 
-This example relies on :func:`aicostmanager.delivery.get_global_delivery` for
-resilient delivery. The helper returns a process-wide background worker that
-batches and retries usage records. When used inside a Celery task the worker is
-started automatically for each worker process so the task only needs to enqueue
-payloads.
+This example uses :class:`aicostmanager.tracker.Tracker` to validate usage
+records and deliver them in the background. The tracker relies on a
+process-wide worker that batches and retries records. When used inside a Celery
+task the worker is started automatically, so the task only needs to enqueue
+usage via :meth:`Tracker.track`.
 
 To **guarantee** that all usage records are delivered before the task finishes,
 call :func:`sync_streaming_sessions` with ``wait=True`` (the default). This
 stops the background worker after the queue is drained. The next task that
-needs to send usage data will spawn a new worker automatically via
-``get_global_delivery``.
+needs to send usage data will spawn a new worker automatically when a new
+tracker instance is created.
 
 If you prefer to let delivery continue in the background, pass ``wait=False``;
 the worker thread will keep running after the task returns and will flush the
@@ -28,11 +28,9 @@ Example Celery task::
 """
 
 import os
-from datetime import datetime, timezone
 import requests
 
-from aicostmanager.client import CostManagerClient
-from aicostmanager.delivery import get_global_delivery
+from aicostmanager.tracker import Tracker
 
 HEYGEN_API_KEY = os.environ.get("HEYGEN_API_KEY")
 AICM_CONFIG_ID = os.environ.get("AICM_CONFIG_ID")
@@ -75,22 +73,16 @@ def sync_streaming_sessions(page_size: int = 100, *, wait: bool = True) -> None:
             "HEYGEN_API_KEY, AICM_CONFIG_ID, and AICM_SERVICE_ID must be set in the environment",
         )
 
-    cm_client = CostManagerClient()
-    delivery = get_global_delivery(cm_client, on_full="block")
+    tracker = Tracker(AICM_CONFIG_ID, AICM_SERVICE_ID, delivery_on_full="block")
 
     for session in iter_sessions(page_size=page_size):
-        payload = {
-            "config_id": AICM_CONFIG_ID,
-            "service_id": AICM_SERVICE_ID,
-            "timestamp": session.get("start_time")
-            or datetime.now(timezone.utc).isoformat(),
-            "response_id": session.get("session_id"),
-            "usage": {"duration": session.get("duration")},
-        }
-        delivery.deliver({"usage_records": [payload]})
+        tracker.track(
+            {"duration": session.get("duration")},
+            response_id=session.get("session_id"),
+        )
 
     if wait:
-        delivery.stop()
+        tracker.close()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- use Tracker.track in HeyGen sync example and close worker when done

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -e '.[test]'` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_b_6899155e6e00832ba3e981268718415c