### PR TITLE
Ensure HeyGen example flushes tracker and document queue behavior

### DIFF
--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -161,11 +161,18 @@ If the usage dictionary does not match the schema a
 
 ## Stopping the delivery worker
 
-The tracker shares the global delivery worker by default.  To shut it down
-cleanly, call ``close`` during application shutdown:
+The tracker shares the global delivery worker by default. To shut it down
+cleanly, call ``close`` during application shutdown. ``close()`` flushes the
+delivery queue and blocks until all pending records have been sent. There is no
+public API to inspect the queue, so wrap tracking in a ``try``/``finally`` block
+to guarantee cleanup:
 
 ```python
-tracker.close()
+tracker = Tracker("cfg", "svc")
+try:
+    tracker.track({"tokens": 5})
+finally:
+    tracker.close()
 ```
 
 ## FastAPI example


### PR DESCRIPTION
## Summary
- guarantee all HeyGen usage is delivered by closing the Tracker in a `finally` block
- explain in docs that `close()` flushes the queue and there's no public queue inspection API

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68991d6d18ec832bb47cb97a93d68647