### PR TITLE
feat: allow custom timestamp in tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,9 @@ tracker.track({
 # Reuse a session or request identifier from the upstream service
 # tracker.track({"tokens": 123, "model": "gpt-4o-mini"}, response_id="session123")
 
+# Provide a custom timestamp if you already recorded one
+# tracker.track({"tokens": 123, "model": "gpt-4o-mini"}, timestamp="2024-01-01T00:00:00Z")
+
 # Async initialization for web apps
 # tracker = await Tracker.create_async("cfg", "svc")
 # tracker.close()  # during shutdown

--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -135,6 +135,7 @@ class Tracker:
         usage: Dict[str, Any],
         *,
         response_id: Optional[str] = None,
+        timestamp: str | datetime | None = None,
         client_customer_key: Optional[str] = None,
         context: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -147,6 +148,9 @@ class Tracker:
         response_id:
             Optional identifier to associate with the usage record. If not
             provided a random UUID4 hex string is generated.
+        timestamp:
+            Optional ISO formatted timestamp for the usage record. When not
+            supplied the current UTC time is used.
         client_customer_key:
             Optional identifier for grouping usage by customer.
         context:
@@ -170,7 +174,11 @@ class Tracker:
         record: Dict[str, Any] = {
             "config_id": self.config_id,
             "service_id": self.service_id,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": (
+                timestamp.isoformat()
+                if isinstance(timestamp, datetime)
+                else timestamp or datetime.now(timezone.utc).isoformat()
+            ),
             "response_id": response_id or uuid4().hex,
             "usage": usage,
         }

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -55,14 +55,20 @@ tracker.track(
 )
 ```
 
-## Custom Response IDs
+## Custom Response IDs and Timestamps
 
-If the API you are tracking provides its own session or request identifier,
-you can use it for the usage record's ``response_id``:
+If the API you are tracking provides its own session or request identifier or
+timestamp, you can supply them instead of letting the tracker generate new
+values:
 
 ```python
 session_id = remote_response["session_id"]
-tracker.track({"duration": 12.3}, response_id=session_id)
+created_at = remote_response["created_at"]
+tracker.track(
+    {"duration": 12.3},
+    response_id=session_id,
+    timestamp=created_at,
+)
 ```
 
 ## Async Initialization (Web Apps)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -68,6 +68,30 @@ def test_tracker_custom_response_id(monkeypatch):
     assert record["response_id"] == "session123"
 
 
+def test_tracker_custom_timestamp(monkeypatch):
+    cfg = Config(
+        uuid="u",
+        config_id="cfg",
+        api_id="api",
+        last_updated="now",
+        handling_config={},
+        manual_usage_schema={"tokens": "int", "model": "str"},
+    )
+
+    def fake_get_config_by_id(self, config_id):
+        return cfg
+
+    monkeypatch.setattr(CostManagerConfig, "get_config_by_id", fake_get_config_by_id)
+    delivery = DummyDelivery()
+    tracker = Tracker("cfg", "svc", aicm_api_key="sk-test", delivery=delivery)
+
+    tracker.track(
+        {"tokens": 10, "model": "gpt"}, timestamp="2024-01-01T00:00:00Z"
+    )
+    record = delivery.payloads[0]["usage_records"][0]
+    assert record["timestamp"] == "2024-01-01T00:00:00Z"
+
+
 def test_tracker_invalid_usage(monkeypatch):
     cfg = Config(
         uuid="u",


### PR DESCRIPTION
## Summary
- allow overriding timestamp and response_id in `Tracker.track`
- document custom timestamps for manual usage tracking
- test `Tracker.track` with provided timestamp

## Testing
- `pytest tests/test_tracker.py::test_tracker_custom_timestamp -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68993c25b88c832b9e3f3cdeb6d2976a