### PR TITLE
Ensure streaming usage delivered on exit

### DIFF
--- a/aicostmanager/delivery.py
+++ b/aicostmanager/delivery.py
@@ -18,6 +18,7 @@ import threading
 import time
 import logging
 import io
+import atexit
 from contextlib import contextmanager
 from typing import Any, Optional, Callable
 
@@ -239,6 +240,9 @@ def get_global_delivery(
             max_batch_size=max_batch_size,
         )
         _global_delivery.start()
+        if not getattr(_global_delivery, "_atexit_registered", False):
+            atexit.register(_global_delivery.stop)
+            _global_delivery._atexit_registered = True
 
         # Ensure the delivery thread is restarted in forked worker processes
         try:  # pragma: no cover - optional multiprocessing hook


### PR DESCRIPTION
## Summary
- auto-flush global delivery on interpreter exit via `atexit`
- safeguard streaming iterators with `weakref.finalize` so usage is reported even if dropped

## Testing
- `pytest tests/test_cost_manager_wrapper.py::test_streaming_finalization -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_689a2610a51c832ba07e1c8f16b67d08