### PR TITLE
Fix persistent delivery wait jitter and update test for latest httpx

### DIFF
--- a/aicostmanager/persistent_delivery.py
+++ b/aicostmanager/persistent_delivery.py
@@ -208,7 +208,7 @@ class PersistentDelivery:
         """Send a payload immediately with retries."""
         for attempt in Retrying(
             stop=stop_after_attempt(self.max_attempts),
-            wait=wait_exponential_jitter(min=1, max=10),
+            wait=wait_exponential_jitter(initial=1, max=10),
         ):
             with attempt:
                 self._send_once(payload)
@@ -225,7 +225,7 @@ class PersistentDelivery:
 
         async for attempt in AsyncRetrying(
             stop=stop_after_attempt(self.max_attempts),
-            wait=wait_exponential_jitter(min=1, max=10),
+            wait=wait_exponential_jitter(initial=1, max=10),
         ):
             with attempt:
                 await _send()

--- a/tests/test_persistent_delivery.py
+++ b/tests/test_persistent_delivery.py
@@ -3,6 +3,7 @@ import tempfile
 import time
 
 import httpx
+import json
 
 from aicostmanager.persistent_delivery import PersistentDelivery
 
@@ -11,7 +12,9 @@ def test_deliver_now_and_enqueue():
     received = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        received.append(request.json())
+        # httpx.Request no longer exposes a ``json`` method in recent versions,
+        # so parse the body manually for compatibility.
+        received.append(json.loads(request.content.decode()))
         return httpx.Response(200, json={"ok": True})
 
     transport = httpx.MockTransport(handler)


### PR DESCRIPTION
## Summary
- use `initial` parameter with tenacity's `wait_exponential_jitter`
- adapt persistent delivery test to parse request JSON without `Request.json`

## Testing
- `AICM_API_KEY=dummy OPENAI_API_KEY=dummy uv run pytest tests/test_persistent_delivery.py`

------
https://chatgpt.com/codex/tasks/task_b_689c776aeb48832bb31738dce15b8f0e