### PR TITLE
Rename Tracker.sync_track to deliver_now

### DIFF
--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -124,7 +124,7 @@ class Tracker:
         )
 
     # ------------------------------------------------------------------
-    def sync_track(
+    def deliver_now(
         self,
         api_id: str,
         system_key: str,
@@ -147,7 +147,7 @@ class Tracker:
         )
         return self.delivery.deliver_now(record)
 
-    async def sync_track_async(
+    async def deliver_now_async(
         self,
         api_id: str,
         system_key: str,
@@ -170,8 +170,10 @@ class Tracker:
         return await self.delivery.deliver_now_async(record)
 
     # Backwards compatible aliases
-    track_sync = sync_track
-    track_sync_async = sync_track_async
+    sync_track = deliver_now
+    sync_track_async = deliver_now_async
+    track_sync = deliver_now
+    track_sync_async = deliver_now_async
 
     # ------------------------------------------------------------------
     def close(self) -> None:

--- a/docs/new_tracker.md
+++ b/docs/new_tracker.md
@@ -15,13 +15,13 @@ usage = {"input_tokens": 1, "output_tokens": 2}
 tracker.track("openai", "gpt-5-mini", usage)
 ```
 
-Use `track_sync` to send immediately without waiting for the background queue:
+Use `deliver_now` to send immediately without waiting for the background queue:
 
 ```python
-tracker.track_sync("openai", "gpt-5-mini", usage)
+tracker.deliver_now("openai", "gpt-5-mini", usage)
 ```
 
-Both methods also have async counterparts `track_async` and `track_sync_async`
+Both methods also have async counterparts `track_async` and `deliver_now_async`
 for use in frameworks such as FastAPI or when running inside Celery tasks.
 Remember to call `close()` on application shutdown so any background worker can
 terminate cleanly.

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -26,11 +26,11 @@ tracker.track({
 })
 ```
 
-To bypass the queue and send immediately, use `sync_track` which returns the
+To bypass the queue and send immediately, use `deliver_now` which returns the
 server response:
 
 ```python
-resp = tracker.sync_track("openai", "gpt-5-mini", {"tokens": 1})
+resp = tracker.deliver_now("openai", "gpt-5-mini", {"tokens": 1})
 assert resp.status_code == 200
 ```
 

--- a/tests/test_real_tracked_events.py
+++ b/tests/test_real_tracked_events.py
@@ -1,9 +1,7 @@
-import os
+import time
 import uuid
 
-import json
-import urllib.error
-import urllib.request
+from aicostmanager import Tracker
 
 VALID_PAYLOAD = {
     "prompt_tokens": 19,
@@ -22,45 +20,39 @@ VALID_PAYLOAD = {
 }
 
 
-def _post_track(api_key: str, api_base: str, payload: dict):
-    api_url = os.getenv("AICM_API_URL", "/api/v1")
-    url = f"{api_base.rstrip('/')}{api_url}/track"
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=data, method="POST")
-    req.add_header("Authorization", f"Bearer {api_key}")
-    req.add_header("User-Agent", "aicostmanager-python")
-    req.add_header("Content-Type", "application/json")
-    try:
-        with urllib.request.urlopen(req) as resp:  # nosec: B310 - used for tests
-            status = resp.getcode()
-            body = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as e:  # pragma: no cover - error path
-        status = e.code
-        body = e.read().decode("utf-8")
-    return status, json.loads(body)
+def _make_tracker(api_key: str, api_base: str, tmp_path) -> Tracker:
+    return Tracker(
+        aicm_api_key=api_key,
+        aicm_api_base=api_base,
+        db_path=str(tmp_path / "queue.db"),
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
 
 
-def test_track_single_event_success(aicm_api_key, aicm_api_base):
-    body = {
-        "tracked": [
-            {
-                "api_id": "openai_chat",
-                "service_key": "openai::gpt-5-mini",
-                "response_id": "evt1",
-                "timestamp": "2025-01-01T00:00:00Z",
-                "payload": VALID_PAYLOAD,
-            }
-        ]
-    }
-    status, data = _post_track(aicm_api_key, aicm_api_base, body)
-    assert status == 201, data
-    assert "event_ids" in data and len(data["event_ids"]) == 1
-    result = data["event_ids"][0]
-    assert "evt1" in result
-    uuid.UUID(result["evt1"])  # validate uuid
+def _wait_for_empty(delivery, timeout: float = 5.0) -> bool:
+    for _ in range(int(timeout / 0.1)):
+        if delivery.get_stats().get("queued", 0) == 0:
+            return True
+        time.sleep(0.1)
+    return False
 
 
-def test_track_multiple_events_with_errors(aicm_api_key, aicm_api_base):
+def test_track_single_event_success(aicm_api_key, aicm_api_base, tmp_path):
+    tracker = _make_tracker(aicm_api_key, aicm_api_base, tmp_path)
+    tracker.track(
+        "openai_chat",
+        "openai::gpt-5-mini",
+        VALID_PAYLOAD,
+        response_id="evt1",
+        timestamp="2025-01-01T00:00:00Z",
+    )
+    assert _wait_for_empty(tracker.delivery)
+    tracker.close()
+
+
+def test_track_multiple_events_with_errors(aicm_api_key, aicm_api_base, tmp_path):
+    tracker = _make_tracker(aicm_api_key, aicm_api_base, tmp_path)
     events = [
         {
             "api_id": "openai_chat",
@@ -123,15 +115,116 @@ def test_track_multiple_events_with_errors(aicm_api_key, aicm_api_base):
         },
     ]
 
-    status, data = _post_track(aicm_api_key, aicm_api_base, {"tracked": events})
-    assert status == 201, data
-    assert "event_ids" in data and len(data["event_ids"]) == len(events)
+    for event in events:
+        tracker.track(
+            event["api_id"],
+            event.get("service_key"),
+            event["payload"],
+            response_id=event.get("response_id"),
+            timestamp=event.get("timestamp"),
+        )
 
-    results = data["event_ids"]
-    # Valid event returns UUID
-    uuid.UUID(results[0]["ok1"])  # should not raise
+    assert _wait_for_empty(tracker.delivery)
+    tracker.close()
 
-    # Check error messages for each invalid event
+
+def test_deliver_now_single_event_success(aicm_api_key, aicm_api_base):
+    tracker = Tracker(aicm_api_key=aicm_api_key, aicm_api_base=aicm_api_base)
+    resp = tracker.deliver_now(
+        "openai_chat",
+        "openai::gpt-5-mini",
+        VALID_PAYLOAD,
+        response_id="evt1",
+        timestamp="2025-01-01T00:00:00Z",
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert "event_ids" in data and len(data["event_ids"]) == 1
+    result = data["event_ids"][0]
+    assert "evt1" in result
+    uuid.UUID(result["evt1"])
+    tracker.close()
+
+
+def test_deliver_now_multiple_events_with_errors(aicm_api_key, aicm_api_base):
+    tracker = Tracker(aicm_api_key=aicm_api_key, aicm_api_base=aicm_api_base)
+    events = [
+        {
+            "api_id": "openai_chat",
+            "service_key": "openai::gpt-5-mini",
+            "response_id": "ok1",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "payload": VALID_PAYLOAD,
+        },
+        {
+            # Missing service_key
+            "api_id": "openai_chat",
+            "response_id": "missing",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "payload": VALID_PAYLOAD,
+        },
+        {
+            # Invalid service_key format
+            "api_id": "openai_chat",
+            "service_key": "invalidformat",
+            "response_id": "badformat",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "payload": VALID_PAYLOAD,
+        },
+        {
+            # Service not found
+            "api_id": "openai_chat",
+            "service_key": "openai::does-not-exist",
+            "response_id": "noservice",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "payload": VALID_PAYLOAD,
+        },
+        {
+            # API client not found
+            "api_id": "nonexistent_client",
+            "service_key": "openai::gpt-5-mini",
+            "response_id": "noapi",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "payload": VALID_PAYLOAD,
+        },
+        {
+            # Payload validation error (missing total_tokens)
+            "api_id": "openai_chat",
+            "service_key": "openai::gpt-5-mini",
+            "response_id": "badpayload",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "payload": {
+                "prompt_tokens": 19,
+                "completion_tokens": 10,
+                "prompt_tokens_details": {
+                    "cached_tokens": 0,
+                    "audio_tokens": 0,
+                },
+                "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "audio_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0,
+                },
+            },
+        },
+    ]
+
+    results = []
+    for event in events:
+        resp = tracker.deliver_now(
+            event["api_id"],
+            event.get("service_key"),
+            event["payload"],
+            response_id=event.get("response_id"),
+            timestamp=event.get("timestamp"),
+        )
+        assert resp.status_code == 201, resp.text
+        results.append(resp.json()["event_ids"][0])
+
+    tracker.close()
+
+    uuid.UUID(results[0]["ok1"])
     assert results[1]["missing"] == ["Missing service_key"]
     assert results[2]["badformat"] == ["Invalid service_key format"]
     assert results[3]["noservice"] == ["Service not found"]
@@ -140,3 +233,4 @@ def test_track_multiple_events_with_errors(aicm_api_key, aicm_api_base):
     assert isinstance(err, list) and any(
         e.startswith("Payload validation error") for e in err
     )
+

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -33,20 +33,22 @@ def test_tracker_enqueue():
     assert "payload" in record
 
 
-def test_tracker_sync_delivery():
+def test_tracker_deliver_now():
     delivery = DummyDelivery()
     tracker = Tracker(delivery=delivery)
-    resp = tracker.sync_track("openai", "gpt-5-mini", {"input_tokens": 1})
+    resp = tracker.deliver_now("openai", "gpt-5-mini", {"input_tokens": 1})
     assert delivery.sent
     assert resp["ok"]
 
 
-def test_tracker_async_delivery():
+def test_tracker_deliver_now_async():
     delivery = DummyDelivery()
     tracker = Tracker(delivery=delivery)
 
     async def run():
-        resp = await tracker.sync_track_async("openai", "gpt-5-mini", {"input_tokens": 1})
+        resp = await tracker.deliver_now_async(
+            "openai", "gpt-5-mini", {"input_tokens": 1}
+        )
         return resp
 
     resp = asyncio.run(run())


### PR DESCRIPTION
## Summary
- rename `Tracker.sync_track` and `sync_track_async` to `deliver_now` and `deliver_now_async`
- update docs and examples to reflect the new names
- expand real tracked events tests to cover queued and immediate delivery

## Testing
- `pytest tests/test_tracker.py tests/test_real_tracked_events.py` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_689cfab2f3d8832b83651edadc0cfac5