### PR TITLE
feat: add detailed logging for batch delivery

### DIFF
--- a/docs/persistent_delivery.md
+++ b/docs/persistent_delivery.md
@@ -20,6 +20,7 @@ Values can be supplied directly or through environment variables and the
 - `AICM_DELIVERY_DB_PATH`
 - `AICM_DELIVERY_LOG_FILE`
 - `AICM_DELIVERY_LOG_LEVEL`
+- `AICM_DELIVERY_LOG_BODIES`
 
 The same options may be placed in a `[delivery]` section inside the INI file.
 
@@ -46,3 +47,8 @@ Call `stop()` to flush and close resources when shutting down.
 ```
 delivery.stop()
 ```
+
+For troubleshooting, full request and response bodies can be logged (with
+common sensitive fields redacted) by passing `log_bodies=True` when creating
+`PersistentDelivery` or setting the environment variable
+`AICM_DELIVERY_LOG_BODIES`.


### PR DESCRIPTION
## Summary
- log batch size, destination, and responses in persistent delivery
- add optional flag to log request/response bodies with redaction
- document new delivery logging options

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests httpx PyJWT` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_689cffe16e8c832b8c4c6fdb554c5254