### PR TITLE
Add tracker tests for multiple LLM providers

### DIFF
--- a/tests/test_anthropic_real_tracker.py
+++ b/tests/test_anthropic_real_tracker.py
@@ -1,0 +1,79 @@
+import time
+import uuid
+
+import json
+import urllib.request
+
+import pytest
+
+anthropic = pytest.importorskip("anthropic")
+from aicostmanager.tracker import Tracker
+
+BASE_URL = "http://127.0.0.1:8001"
+
+
+def _wait_for_cost_event(aicm_api_key: str, response_id: str, timeout: int = 30):
+    """Poll the server until a cost event for ``response_id`` appears."""
+    headers = {"Authorization": f"Bearer {aicm_api_key}"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{BASE_URL}/api/v1/cost-events/{response_id}",
+                headers=headers,
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    data = json.load(resp)
+                    event_id = data.get("event_id") or data.get("cost_event", {}).get("event_id")
+                    if event_id:
+                        uuid.UUID(str(event_id))
+                        return data
+        except Exception:
+            pass
+        time.sleep(1)
+    raise AssertionError(f"cost event for {response_id} not found")
+
+
+@pytest.mark.parametrize(
+    "service_key, model",
+    [
+        ("anthropic::claude-sonnet-4-20250514", "claude-3-haiku-20240307"),
+        ("anthropic::claude-sonnet-4", "claude-3-haiku-20240307"),
+    ],
+)
+def test_anthropic_tracker(service_key, model, anthropic_api_key, aicm_api_key):
+    if not anthropic_api_key:
+        pytest.skip("ANTHROPIC_API_KEY not set in .env file")
+    tracker = Tracker(
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=BASE_URL,
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    client = anthropic.Anthropic(api_key=anthropic_api_key)
+
+    # Background tracking via queue
+    resp = client.messages.create(
+        model=model,
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=20,
+    )
+    response_id = resp.id
+    tracker.track("anthropic", service_key, {"input_tokens": 1}, response_id=response_id)
+    _wait_for_cost_event(aicm_api_key, response_id)
+
+    # Immediate delivery
+    resp2 = client.messages.create(
+        model=model,
+        messages=[{"role": "user", "content": "Say hi again"}],
+        max_tokens=20,
+    )
+    response_id2 = resp2.id
+    delivery_resp = tracker.deliver_now(
+        "anthropic", service_key, {"input_tokens": 1}, response_id=response_id2
+    )
+    assert delivery_resp.status_code in (200, 201)
+    _wait_for_cost_event(aicm_api_key, response_id2)
+
+    tracker.close()

--- a/tests/test_bedrock_real_tracker.py
+++ b/tests/test_bedrock_real_tracker.py
@@ -1,0 +1,83 @@
+import time
+import json
+import uuid
+import urllib.request
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+
+from aicostmanager.tracker import Tracker
+
+BASE_URL = "http://127.0.0.1:8001"
+
+
+def _wait_for_cost_event(aicm_api_key: str, response_id: str, timeout: int = 30):
+    headers = {"Authorization": f"Bearer {aicm_api_key}"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{BASE_URL}/api/v1/cost-events/{response_id}",
+                headers=headers,
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    data = json.load(resp)
+                    event_id = data.get("event_id") or data.get("cost_event", {}).get("event_id")
+                    if event_id:
+                        uuid.UUID(str(event_id))
+                        return data
+        except Exception:
+            pass
+        time.sleep(1)
+    raise AssertionError(f"cost event for {response_id} not found")
+
+
+@pytest.mark.parametrize(
+    "service_key, model_id",
+    [
+        ("amazon-bedrock::amazon.nova-pro-v1:0", "amazon.nova-pro-v1:0"),
+        ("amazon-bedrock::us.meta.llama3-3-70b-instruct-v1:0", "us.meta.llama3-3-70b-instruct-v1:0"),
+        ("amazon-bedrock::us.amazon.nova-pro-v1:0", "us.amazon.nova-pro-v1:0"),
+    ],
+)
+def test_bedrock_tracker(service_key, model_id, aws_region, aicm_api_key):
+    if not aws_region:
+        pytest.skip("AWS_DEFAULT_REGION not set in .env file")
+    tracker = Tracker(
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=BASE_URL,
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    client = boto3.client("bedrock-runtime", region_name=aws_region)
+
+    body = {
+        "messages": [{"role": "user", "content": [{"text": "Say hi"}]}],
+        "inferenceConfig": {"maxTokens": 50},
+    }
+    response = client.converse(modelId=model_id, **body)
+    response_id = (
+        response.get("output", {}).get("message", {}).get("id")
+        or response.get("ResponseMetadata", {}).get("RequestId")
+    )
+    tracker.track("amazon-bedrock", service_key, {"input_tokens": 1}, response_id=response_id)
+    _wait_for_cost_event(aicm_api_key, response_id)
+
+    body2 = {
+        "messages": [{"role": "user", "content": [{"text": "Say hi again"}]}],
+        "inferenceConfig": {"maxTokens": 50},
+    }
+    response2 = client.converse(modelId=model_id, **body2)
+    response_id2 = (
+        response2.get("output", {}).get("message", {}).get("id")
+        or response2.get("ResponseMetadata", {}).get("RequestId")
+    )
+    delivery_resp = tracker.deliver_now(
+        "amazon-bedrock", service_key, {"input_tokens": 1}, response_id=response_id2
+    )
+    assert delivery_resp.status_code in (200, 201)
+    _wait_for_cost_event(aicm_api_key, response_id2)
+
+    tracker.close()

--- a/tests/test_gemini_real_tracker.py
+++ b/tests/test_gemini_real_tracker.py
@@ -1,0 +1,69 @@
+import time
+import json
+import uuid
+import urllib.request
+
+import pytest
+
+genai = pytest.importorskip("google.genai")
+
+from aicostmanager.tracker import Tracker
+
+BASE_URL = "http://127.0.0.1:8001"
+
+
+def _wait_for_cost_event(aicm_api_key: str, response_id: str, timeout: int = 30):
+    headers = {"Authorization": f"Bearer {aicm_api_key}"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{BASE_URL}/api/v1/cost-events/{response_id}",
+                headers=headers,
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    data = json.load(resp)
+                    event_id = data.get("event_id") or data.get("cost_event", {}).get("event_id")
+                    if event_id:
+                        uuid.UUID(str(event_id))
+                        return data
+        except Exception:
+            pass
+        time.sleep(1)
+    raise AssertionError(f"cost event for {response_id} not found")
+
+
+@pytest.mark.parametrize(
+    "service_key, model",
+    [("google::gemini-2.5-flash", "gemini-2.5-flash")],
+)
+def test_gemini_tracker(service_key, model, google_api_key, aicm_api_key):
+    if not google_api_key:
+        pytest.skip("GOOGLE_API_KEY not set in .env file")
+    tracker = Tracker(
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=BASE_URL,
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    client = genai.Client(api_key=google_api_key)
+
+    response = client.models.generate_content(model=model, contents="Say hi")
+    response_id = getattr(response, "id", None) or getattr(response, "response_id", None)
+    if not response_id:
+        pytest.skip("No response_id returned by Gemini")
+    tracker.track("gemini", service_key, {"input_tokens": 1}, response_id=response_id)
+    _wait_for_cost_event(aicm_api_key, response_id)
+
+    response2 = client.models.generate_content(model=model, contents="Say hi again")
+    response_id2 = getattr(response2, "id", None) or getattr(response2, "response_id", None)
+    if not response_id2:
+        pytest.skip("No response_id returned by Gemini")
+    delivery_resp = tracker.deliver_now(
+        "gemini", service_key, {"input_tokens": 1}, response_id=response_id2
+    )
+    assert delivery_resp.status_code in (200, 201)
+    _wait_for_cost_event(aicm_api_key, response_id2)
+
+    tracker.close()

--- a/tests/test_openai_chat_real_tracker.py
+++ b/tests/test_openai_chat_real_tracker.py
@@ -1,0 +1,95 @@
+import json
+import os
+import time
+import uuid
+import urllib.request
+
+import pytest
+
+openai = pytest.importorskip("openai")
+from aicostmanager.tracker import Tracker
+
+BASE_URL = "http://127.0.0.1:8001"
+
+
+def _wait_for_cost_event(aicm_api_key: str, response_id: str, timeout: int = 30):
+    headers = {"Authorization": f"Bearer {aicm_api_key}"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{BASE_URL}/api/v1/cost-events/{response_id}",
+                headers=headers,
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    data = json.load(resp)
+                    event_id = data.get("event_id") or data.get("cost_event", {}).get("event_id")
+                    if event_id:
+                        uuid.UUID(str(event_id))
+                        return data
+        except Exception:
+            pass
+        time.sleep(1)
+    raise AssertionError(f"cost event for {response_id} not found")
+
+
+def _make_openai_client(api_key: str):
+    return openai.OpenAI(api_key=api_key)
+
+
+def _make_fireworks_client(api_key: str):
+    return openai.OpenAI(api_key=api_key, base_url="https://api.fireworks.ai/inference/v1")
+
+
+def _make_xai_client(api_key: str):
+    return openai.OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
+
+
+@pytest.mark.parametrize(
+    "service_key, model, key_env, maker",
+    [
+        ("openai::gpt-5-mini", "gpt-5-mini", "OPENAI_API_KEY", _make_openai_client),
+        (
+            "fireworks-ai::accounts/fireworks/models/deepseek-r1",
+            "accounts/fireworks/models/deepseek-r1",
+            "FIREWORKS_API_KEY",
+            _make_fireworks_client,
+        ),
+        ("xai::grok-3-mini", "grok-3-mini", "XAI_API_KEY", _make_xai_client),
+    ],
+)
+def test_openai_chat_tracker(service_key, model, key_env, maker, aicm_api_key):
+    api_key = os.environ.get(key_env)
+    if not api_key:
+        pytest.skip(f"{key_env} not set in .env file")
+    tracker = Tracker(
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=BASE_URL,
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    client = maker(api_key)
+
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=20,
+    )
+    response_id = getattr(resp, "id", None)
+    tracker.track("openai_chat", service_key, {"input_tokens": 1}, response_id=response_id)
+    _wait_for_cost_event(aicm_api_key, response_id)
+
+    resp2 = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": "Say hi again"}],
+        max_tokens=20,
+    )
+    response_id2 = getattr(resp2, "id", None)
+    delivery_resp = tracker.deliver_now(
+        "openai_chat", service_key, {"input_tokens": 1}, response_id=response_id2
+    )
+    assert delivery_resp.status_code in (200, 201)
+    _wait_for_cost_event(aicm_api_key, response_id2)
+
+    tracker.close()

--- a/tests/test_openai_responses_real_tracker.py
+++ b/tests/test_openai_responses_real_tracker.py
@@ -1,0 +1,64 @@
+import time
+import json
+import uuid
+import urllib.request
+
+import pytest
+
+openai = pytest.importorskip("openai")
+from aicostmanager.tracker import Tracker
+
+BASE_URL = "http://127.0.0.1:8001"
+
+
+def _wait_for_cost_event(aicm_api_key: str, response_id: str, timeout: int = 30):
+    headers = {"Authorization": f"Bearer {aicm_api_key}"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{BASE_URL}/api/v1/cost-events/{response_id}",
+                headers=headers,
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    data = json.load(resp)
+                    event_id = data.get("event_id") or data.get("cost_event", {}).get("event_id")
+                    if event_id:
+                        uuid.UUID(str(event_id))
+                        return data
+        except Exception:
+            pass
+        time.sleep(1)
+    raise AssertionError(f"cost event for {response_id} not found")
+
+
+@pytest.mark.parametrize(
+    "service_key, model",
+    [("openai::gpt-5-mini", "gpt-5-mini")],
+)
+def test_openai_responses_tracker(service_key, model, openai_api_key, aicm_api_key):
+    if not openai_api_key:
+        pytest.skip("OPENAI_API_KEY not set in .env file")
+    tracker = Tracker(
+        aicm_api_key=aicm_api_key,
+        aicm_api_base=BASE_URL,
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    client = openai.OpenAI(api_key=openai_api_key)
+
+    resp = client.responses.create(model=model, input="Say hi")
+    response_id = getattr(resp, "id", None)
+    tracker.track("openai_responses", service_key, {"input_tokens": 1}, response_id=response_id)
+    _wait_for_cost_event(aicm_api_key, response_id)
+
+    resp2 = client.responses.create(model=model, input="Say hi again")
+    response_id2 = getattr(resp2, "id", None)
+    delivery_resp = tracker.deliver_now(
+        "openai_responses", service_key, {"input_tokens": 1}, response_id=response_id2
+    )
+    assert delivery_resp.status_code in (200, 201)
+    _wait_for_cost_event(aicm_api_key, response_id2)
+
+    tracker.close()


### PR DESCRIPTION
## Summary
- add tracker-based integration tests for Anthropic, Gemini, Bedrock, OpenAI Chat, and OpenAI Responses
- each test exercises Tracker.track and Tracker.deliver_now and polls the cost-events endpoint for a UUID response

## Testing
- `pytest tests/test_anthropic_real_tracker.py tests/test_gemini_real_tracker.py tests/test_bedrock_real_tracker.py tests/test_openai_chat_real_tracker.py tests/test_openai_responses_real_tracker.py`


------
https://chatgpt.com/codex/tasks/task_b_689e1dcbf0a4832b807af4b1580aa9bd