### PR TITLE
Add LimitsManager for triggered limits handling

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -47,6 +47,7 @@ from .models import (
 from .rest_cost_manager import AsyncRestCostManager, RestCostManager
 from .tracker import Tracker
 from .universal_extractor import UniversalExtractor
+from .limits_manager import LimitsManager
 
 __all__ = [
     "AICMError",
@@ -66,6 +67,7 @@ __all__ = [
     "get_global_delivery",
     "get_global_delivery_health",
     "Tracker",
+    "LimitsManager",
     "ApiUsageRecord",
     "ApiUsageRequest",
     "ApiUsageResponse",

--- a/aicostmanager/ini_manager.py
+++ b/aicostmanager/ini_manager.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import tempfile
+import time
+from contextlib import contextmanager
+
+
+@contextmanager
+def _file_lock(file_path: str):
+    """Context manager for file locking to prevent race conditions."""
+    if not file_path:
+        yield
+        return
+    lock_file = f"{file_path}.lock"
+    dir_path = os.path.dirname(file_path)
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+    max_retries = 10
+    retry_delay = 0.1
+    for attempt in range(max_retries):
+        try:
+            lock_fd = os.open(lock_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            break
+        except FileExistsError:
+            if attempt == max_retries - 1:
+                try:
+                    stat = os.stat(lock_file)
+                    if time.time() - stat.st_mtime > 30:
+                        os.unlink(lock_file)
+                        continue
+                except (OSError, FileNotFoundError):
+                    pass
+                raise RuntimeError(f"Could not acquire lock for {file_path}")
+            time.sleep(retry_delay * (2 ** attempt))
+    try:
+        yield
+    finally:
+        try:
+            os.close(lock_fd)
+            os.unlink(lock_file)
+        except (OSError, FileNotFoundError):
+            pass
+
+
+def _safe_read_config(ini_path: str) -> configparser.ConfigParser:
+    config = configparser.ConfigParser(allow_no_value=True, strict=False)
+    if not os.path.exists(ini_path):
+        return config
+    try:
+        config.read(ini_path)
+        return config
+    except configparser.DuplicateSectionError:
+        _clean_duplicate_sections(ini_path)
+        config = configparser.ConfigParser(allow_no_value=True, strict=False)
+        config.read(ini_path)
+        return config
+
+
+def _clean_duplicate_sections(ini_path: str) -> None:
+    if not os.path.exists(ini_path):
+        return
+    seen_sections: set[str] = set()
+    cleaned_lines: list[str] = []
+    current_section: str | None = None
+    section_content: list[str] = []
+    with open(ini_path, "r") as f:
+        lines = f.readlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if current_section is not None:
+                if current_section not in seen_sections:
+                    cleaned_lines.extend(section_content)
+                    seen_sections.add(current_section)
+                section_content = []
+            current_section = stripped
+            section_content = [line]
+        else:
+            section_content.append(line)
+    if current_section is not None and current_section not in seen_sections:
+        cleaned_lines.extend(section_content)
+    _atomic_write(ini_path, "".join(cleaned_lines))
+
+
+def _atomic_write(file_path: str, content: str) -> None:
+    if not file_path:
+        return
+    dir_path = os.path.dirname(file_path)
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+    temp_dir = dir_path if dir_path else "."
+    temp_fd, temp_path = tempfile.mkstemp(dir=temp_dir, prefix=f".{os.path.basename(file_path)}.tmp")
+    try:
+        with os.fdopen(temp_fd, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(temp_path, file_path)
+    except Exception:
+        try:
+            os.unlink(temp_path)
+        except (OSError, FileNotFoundError):
+            pass
+        raise
+
+
+class IniManager:
+    """Handle reading and writing triggered limits to the INI file."""
+
+    def __init__(self, ini_path: str) -> None:
+        self.ini_path = ini_path
+        with _file_lock(self.ini_path):
+            self._config = _safe_read_config(self.ini_path)
+
+    def _write(self) -> None:
+        with _file_lock(self.ini_path):
+            import io
+            content = io.StringIO()
+            self._config.write(content)
+            _atomic_write(self.ini_path, content.getvalue())
+
+    def read_triggered_limits(self) -> dict:
+        with _file_lock(self.ini_path):
+            self._config = _safe_read_config(self.ini_path)
+        if (
+            "triggered_limits" not in self._config
+            or "payload" not in self._config["triggered_limits"]
+        ):
+            return {}
+        return json.loads(self._config["triggered_limits"].get("payload", "{}"))
+
+    def write_triggered_limits(self, data: dict) -> None:
+        if "triggered_limits" in self._config:
+            self._config.remove_section("triggered_limits")
+        self._config.add_section("triggered_limits")
+        self._config["triggered_limits"]["payload"] = json.dumps(data or {})
+        self._write()

--- a/aicostmanager/limits_manager.py
+++ b/aicostmanager/limits_manager.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+import jwt
+
+from .client import CostManagerClient
+from .ini_manager import IniManager
+
+
+class LimitsManager:
+    """Manage triggered limits fetched from the API and stored locally."""
+
+    def __init__(self, client: CostManagerClient, ini_manager: IniManager | None = None) -> None:
+        self.client = client
+        self.ini_manager = ini_manager or IniManager(client.ini_path)
+
+    def _decode(self, token: str, public_key: str) -> Optional[dict]:
+        try:
+            return jwt.decode(token, public_key, algorithms=["RS256"], issuer="aicm-api")
+        except Exception:
+            return None
+
+    def update_triggered_limits(self) -> None:
+        """Fetch triggered limits from the API and persist them to the INI file."""
+        data = self.client.get_triggered_limits() or {}
+        if isinstance(data, dict):
+            tl_data = data.get("triggered_limits", data)
+        else:
+            tl_data = data
+        self.ini_manager.write_triggered_limits(tl_data)
+
+    def check_triggered_limits(
+        self,
+        api_key_id: str,
+        service_key: Optional[str] = None,
+        client_customer_key: Optional[str] = None,
+    ) -> List[dict]:
+        """Return triggered limit events matching the provided parameters."""
+        tl_raw = self.ini_manager.read_triggered_limits()
+        token = tl_raw.get("encrypted_payload")
+        public_key = tl_raw.get("public_key")
+        if not token or not public_key:
+            return []
+        payload = self._decode(token, public_key)
+        if not payload:
+            return []
+        results: List[dict] = []
+        for event in payload.get("triggered_limits", []):
+            if event.get("api_key_id") != api_key_id:
+                continue
+            if service_key and event.get("service_key") != service_key:
+                continue
+            if (
+                client_customer_key
+                and event.get("client_customer_key") != client_customer_key
+            ):
+                continue
+            results.append(event)
+        return results

--- a/tests/test_limits_manager.py
+++ b/tests/test_limits_manager.py
@@ -1,0 +1,70 @@
+import pathlib
+import time
+
+import jwt
+
+from aicostmanager.client import CostManagerClient
+from aicostmanager.ini_manager import IniManager
+from aicostmanager.limits_manager import LimitsManager
+
+PRIVATE_KEY = (pathlib.Path(__file__).parent / "threshold_private_key.pem").read_text()
+PUBLIC_KEY = (pathlib.Path(__file__).parent / "threshold_public_key.pem").read_text()
+
+
+def _make_triggered_limits():
+    now = int(time.time())
+    event = {
+        "event_id": "evt-api-key-limit",
+        "limit_id": "lmt-api-key-limit",
+        "threshold_type": "limit",
+        "amount": 100.0,
+        "period": "month",
+        "limit_context": "key",
+        "limit_message": "Usage limit exceeded",
+        "service_key": "openai::gpt-4",
+        "client_customer_key": "api-key-customer",
+        "api_key_id": "550e8400-e29b-41d4-a716-446655440000",
+        "triggered_at": "2024-12-31T18:00:00Z",
+        "expires_at": "2025-01-01T18:00:00Z",
+    }
+    payload = {
+        "iss": "aicm-api",
+        "sub": "550e8400-e29b-41d4-a716-446655440000",
+        "iat": now,
+        "jti": "tl",
+        "version": "v1",
+        "key_id": "test",
+        "triggered_limits": [event],
+    }
+    token = jwt.encode(payload, PRIVATE_KEY, algorithm="RS256", headers={"kid": "test"})
+    item = {"version": "v1", "public_key": PUBLIC_KEY, "key_id": "test", "encrypted_payload": token}
+    return item, event
+
+
+def test_update_and_check(monkeypatch, tmp_path):
+    ini = tmp_path / "AICM.ini"
+    client = CostManagerClient(aicm_api_key="sk-test", aicm_ini_path=str(ini))
+    ini_mgr = IniManager(str(ini))
+    limits_mgr = LimitsManager(client, ini_mgr)
+
+    item, event = _make_triggered_limits()
+    monkeypatch.setattr(client, "get_triggered_limits", lambda: item)
+
+    limits_mgr.update_triggered_limits()
+
+    stored = ini_mgr.read_triggered_limits()
+    assert stored.get("encrypted_payload") == item["encrypted_payload"]
+
+    matches = limits_mgr.check_triggered_limits(
+        api_key_id=event["api_key_id"], service_key=event["service_key"]
+    )
+    assert len(matches) == 1
+    assert matches[0]["limit_id"] == event["limit_id"]
+
+    no_match = limits_mgr.check_triggered_limits(
+        api_key_id=event["api_key_id"], service_key="other-service"
+    )
+    assert no_match == []
+
+    wrong_api = limits_mgr.check_triggered_limits(api_key_id="different")
+    assert wrong_api == []


### PR DESCRIPTION
## Summary
- add `IniManager` to manage INI file locking and triggered limit payloads
- introduce `LimitsManager` to fetch and inspect triggered limits
- expose `LimitsManager` from package and add basic tests

## Testing
- ⚠️ `pytest tests/test_limits_manager.py` *(missing dependency `jwt`)*

------
https://chatgpt.com/codex/tasks/task_b_68a23fcf9054832bbfa92c12c18e14b7