### PR TITLE
Add flexible delivery managers for Tracker

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -13,6 +13,13 @@ from .client import (
 )
 from .config_manager import CostManagerConfig
 from .cost_manager import CostManager
+from .delivery_manager import (
+    DeliveryManager,
+    DeliveryManagerType,
+    ImmediateDeliveryManager,
+    MemQueueDeliveryManager,
+    PersistentQueueDeliveryManager,
+)
 from .delivery import (
     ResilientDelivery,
     get_global_delivery,
@@ -63,6 +70,11 @@ __all__ = [
     "UsageLimitExceeded",
     "CostManagerConfig",
     "UniversalExtractor",
+    "DeliveryManager",
+    "DeliveryManagerType",
+    "ImmediateDeliveryManager",
+    "MemQueueDeliveryManager",
+    "PersistentQueueDeliveryManager",
     "ResilientDelivery",
     "PersistentDelivery",
     "get_global_delivery",

--- a/aicostmanager/delivery_manager.py
+++ b/aicostmanager/delivery_manager.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import threading
+import time
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+import httpx
+from tenacity import (
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from .persistent_delivery import PersistentDelivery
+
+
+logger = logging.getLogger(__name__)
+
+
+class DeliveryManager(ABC):
+    """Abstract base class for tracker delivery mechanisms."""
+
+    @abstractmethod
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        """Queue ``payload`` for background delivery."""
+
+    def stop(self) -> None:  # pragma: no cover - default no-op
+        """Shutdown any background resources."""
+        return None
+
+
+class DeliveryManagerType(str, Enum):
+    """Available delivery manager implementations."""
+
+    IMMEDIATE = "immediate"
+    MEM_QUEUE = "mem_queue"
+    PERSISTENT_QUEUE = "persistent_queue"
+
+
+class ImmediateDeliveryManager(DeliveryManager):
+    """Synchronous delivery using direct HTTP requests with retries."""
+
+    def __init__(
+        self,
+        *,
+        aicm_api_key: Optional[str] = None,
+        aicm_api_base: Optional[str] = None,
+        aicm_api_url: Optional[str] = None,
+        timeout: float = 10.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.api_key = aicm_api_key or os.getenv("AICM_API_KEY")
+        self.api_base = aicm_api_base or os.getenv(
+            "AICM_API_BASE", "https://aicostmanager.com"
+        )
+        self.api_url = aicm_api_url or os.getenv("AICM_API_URL", "/api/v1")
+        self.timeout = timeout
+        self._transport = transport
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+        self._endpoint = (
+            self.api_base.rstrip("/") + self.api_url.rstrip("/") + "/track"
+        )
+        self._headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "User-Agent": "aicostmanager-python",
+        }
+
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        body = {"tracked": [payload]}
+
+        def _retryable(exc: Exception) -> bool:
+            if isinstance(exc, httpx.HTTPStatusError):
+                return exc.response is None or exc.response.status_code >= 500
+            return True
+
+        for attempt in Retrying(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential_jitter(),
+            retry=retry_if_exception(_retryable),
+        ):
+            with attempt:
+                resp = self._client.post(
+                    self._endpoint, json=body, headers=self._headers
+                )
+                resp.raise_for_status()
+                return None
+
+    def stop(self) -> None:  # pragma: no cover - nothing to cleanup
+        self._client.close()
+
+
+class MemQueueDeliveryManager(DeliveryManager):
+    """In-memory queue with background delivery similar to ``ResilientDelivery``."""
+
+    def __init__(
+        self,
+        *,
+        aicm_api_key: Optional[str] = None,
+        aicm_api_base: Optional[str] = None,
+        aicm_api_url: Optional[str] = None,
+        timeout: float = 10.0,
+        max_retries: int = 5,
+        queue_size: int = 1000,
+        batch_interval: float = 0.5,
+        max_batch_size: int = 100,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.api_key = aicm_api_key or os.getenv("AICM_API_KEY")
+        self.api_base = aicm_api_base or os.getenv(
+            "AICM_API_BASE", "https://aicostmanager.com"
+        )
+        self.api_url = aicm_api_url or os.getenv("AICM_API_URL", "/api/v1")
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.batch_interval = batch_interval
+        self.max_batch_size = max_batch_size
+        self._transport = transport
+        self._endpoint = (
+            self.api_base.rstrip("/") + self.api_url.rstrip("/") + "/track"
+        )
+        self._headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "User-Agent": "aicostmanager-python",
+        }
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+        self._queue: queue.Queue[Dict[str, Any]] = queue.Queue(maxsize=queue_size)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    # Worker thread ---------------------------------------------------
+    def _run(self) -> None:
+        batch: List[Dict[str, Any]] = []
+        last_flush = time.time()
+        while not self._stop.is_set():
+            try:
+                item = self._queue.get(timeout=self.batch_interval)
+                batch.append(item)
+                if len(batch) >= self.max_batch_size:
+                    self._send_batch(batch)
+                    batch = []
+                    last_flush = time.time()
+            except queue.Empty:
+                pass
+            if batch and (time.time() - last_flush) >= self.batch_interval:
+                self._send_batch(batch)
+                batch = []
+                last_flush = time.time()
+        # Drain remaining items
+        while True:
+            try:
+                batch.append(self._queue.get_nowait())
+                if len(batch) >= self.max_batch_size:
+                    self._send_batch(batch)
+                    batch = []
+            except queue.Empty:
+                break
+        if batch:
+            self._send_batch(batch)
+        self._client.close()
+
+    def _send_batch(self, payloads: List[Dict[str, Any]]) -> httpx.Response:
+        body = {"tracked": payloads}
+        for attempt in Retrying(
+            stop=stop_after_attempt(self.max_retries),
+            wait=wait_exponential_jitter(),
+        ):
+            with attempt:
+                resp = self._client.post(
+                    self._endpoint, json=body, headers=self._headers
+                )
+                resp.raise_for_status()
+                return resp
+        raise RuntimeError("unreachable")
+
+    # DeliveryManager interface --------------------------------------
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        try:
+            self._queue.put_nowait(payload)
+        except queue.Full:
+            logger.warning("Delivery queue full")
+
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join()
+
+
+class PersistentQueueDeliveryManager(DeliveryManager):
+    """Wrapper around :class:`PersistentDelivery` using the ``DeliveryManager`` interface."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._delivery = PersistentDelivery(**kwargs)
+
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        self._delivery.enqueue(payload)
+
+    def stop(self) -> None:
+        self._delivery.stop()

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -13,6 +13,16 @@ from aicostmanager import Tracker
 tracker = Tracker()
 ```
 
+## Choosing a delivery manager
+
+The tracker supports multiple delivery strategies selected via `DeliveryManagerType`. The default `immediate` mode sends each record synchronously with up to three retries for transient errors. Use `mem_queue` for an in-memory background queue or `persistent_queue` for a durable SQLite-backed queue:
+
+```python
+from aicostmanager import Tracker, DeliveryManagerType
+
+tracker = Tracker(delivery_type=DeliveryManagerType.MEM_QUEUE)
+```
+
 The constructor accepts the same connection options as
 `PersistentDelivery`, such as `aicm_api_key`, `aicm_api_base` and
 `aicm_ini_path`.  The delivery system writes logs to the Python logging
@@ -50,29 +60,14 @@ tracker.track(
 )
 ```
 
-## Immediate delivery
-
-Use `deliver_now` to bypass the queue and synchronously send a record.
-The method returns the `httpx.Response` from the server so tests can
-assert on the result:
-
-```python
-resp = tracker.deliver_now("openai", "gpt-5-mini", usage)
-assert resp.status_code == 200
-```
-
-Alias methods `sync_track` and `track_sync` are provided for backwards
-compatibility and behave identically to `deliver_now`.
-
 ## Asynchronous usage
 
 All operations are safe to call from asynchronous applications.  The
-methods `track_async` and `deliver_now_async` run the corresponding
-synchronous logic in a worker thread:
+method `track_async` runs the corresponding synchronous logic in a worker
+thread:
 
 ```python
 await tracker.track_async("openai", "gpt-5-mini", usage)
-response = await tracker.deliver_now_async("openai", "gpt-5-mini", usage)
 ```
 
 Example FastAPI integration:

--- a/tests/test_delivery_manager.py
+++ b/tests/test_delivery_manager.py
@@ -1,0 +1,101 @@
+import json
+import time
+
+import httpx
+
+from aicostmanager import Tracker, DeliveryManagerType
+
+
+def test_tracker_default_immediate_delivery():
+    received = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        received.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    tracker = Tracker(aicm_api_key="test", transport=transport)
+    tracker.track("openai", "gpt-5-mini", {"input_tokens": 1})
+    assert received and received[0]["tracked"][0]["api_id"] == "openai"
+    tracker.close()
+
+
+def test_tracker_mem_queue_delivery():
+    received = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        received.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    tracker = Tracker(
+        delivery_type=DeliveryManagerType.MEM_QUEUE,
+        aicm_api_key="test",
+        transport=transport,
+        batch_interval=0.1,
+    )
+    tracker.track("openai", "gpt-5-mini", {"input_tokens": 1})
+    for _ in range(20):
+        if received:
+            break
+        time.sleep(0.1)
+    tracker.close()
+    assert received
+
+
+def test_tracker_persistent_queue_delivery(tmp_path):
+    received = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        received.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    db_path = tmp_path / "queue.db"
+    tracker = Tracker(
+        delivery_type=DeliveryManagerType.PERSISTENT_QUEUE,
+        aicm_api_key="test",
+        db_path=str(db_path),
+        transport=transport,
+        poll_interval=0.1,
+    )
+    tracker.track("openai", "gpt-5-mini", {"input_tokens": 1})
+    for _ in range(20):
+        if received:
+            break
+        time.sleep(0.1)
+    tracker.close()
+    assert received
+
+
+def test_immediate_delivery_retries():
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            return httpx.Response(500, json={"ok": False})
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    tracker = Tracker(aicm_api_key="test", transport=transport)
+    tracker.track("openai", "gpt-5-mini", {"input_tokens": 1})
+    tracker.close()
+    assert attempts["count"] == 3
+
+
+def test_immediate_delivery_does_not_retry_client_error():
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(400, json={"ok": False})
+
+    transport = httpx.MockTransport(handler)
+    tracker = Tracker(aicm_api_key="test", transport=transport)
+    try:
+        tracker.track("openai", "gpt-5-mini", {"input_tokens": 1})
+    except httpx.HTTPStatusError:
+        pass
+    tracker.close()
+    assert attempts["count"] == 1

--- a/tests/test_ini_manager_options.py
+++ b/tests/test_ini_manager_options.py
@@ -1,0 +1,10 @@
+from aicostmanager.ini_manager import IniManager
+
+
+def test_ini_manager_set_get(tmp_path):
+    ini_path = tmp_path / "AICM.INI"
+    mgr = IniManager(str(ini_path))
+    mgr.set_option("tracker", "delivery_manager", "mem_queue")
+    assert (
+        mgr.get_option("tracker", "delivery_manager") == "mem_queue"
+    )


### PR DESCRIPTION
## Summary
- refine Tracker to select delivery strategy via `DeliveryManagerType`
- add smart retry logic for immediate delivery and drop `deliver_now` helpers
- document delivery selection and async tracking

## Testing
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx (ProxyError: Tunnel connection failed: 403 Forbidden))*
- `pytest tests/test_delivery_manager.py tests/test_tracker.py tests/test_ini_manager_options.py` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_68a27acc1a44832b9b7dc1af74d3ce17