### PR TITLE
refactor: centralize delivery config and limits managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,11 +422,11 @@ pip install -e .
 You can inspect background delivery metrics programmatically:
 
 ```python
-from aicostmanager import get_global_delivery_health
+from aicostmanager import Tracker
 
-health = get_global_delivery_health()
-if health:
-    print(health["queue_size"], health["total_discarded"], health["last_error"])
+tracker = Tracker()
+health = tracker.delivery.stats()
+print(health["queued"], health["total_failed"])
 ```
 
 ## 🤝 Contributing

--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -19,8 +19,6 @@ from .delivery import (
     ImmediateDelivery,
     MemQueueDelivery,
     PersistentDelivery,
-    get_global_delivery,
-    get_global_delivery_health,
 )
 from .models import (
     ApiUsageRecord,
@@ -51,7 +49,8 @@ from .models import (
 from .rest_cost_manager import AsyncRestCostManager, RestCostManager
 from .tracker import Tracker
 from .universal_extractor import UniversalExtractor
-from .limits_manager import LimitsManager
+from .triggered_limit_manager import TriggeredLimitManager
+from .usage_limit_manager import UsageLimitManager
 
 __all__ = [
     "AICMError",
@@ -71,10 +70,9 @@ __all__ = [
     "ImmediateDelivery",
     "MemQueueDelivery",
     "PersistentDelivery",
-    "get_global_delivery",
-    "get_global_delivery_health",
     "Tracker",
-    "LimitsManager",
+    "TriggeredLimitManager",
+    "UsageLimitManager",
     "ApiUsageRecord",
     "ApiUsageRequest",
     "ApiUsageResponse",

--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 from .client import CostManagerClient, UsageLimitExceeded
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
-from .delivery import MemQueueDelivery, get_global_delivery
+from .delivery import MemQueueDelivery
 from .universal_extractor import UniversalExtractor
 
 
@@ -61,7 +61,7 @@ class CostManager:
         if delivery is not None:
             self.delivery = delivery
         else:
-            self.delivery = get_global_delivery(
+            self.delivery = MemQueueDelivery(
                 aicm_api_key=aicm_api_key,
                 aicm_api_base=aicm_api_base,
                 aicm_api_url=aicm_api_url,

--- a/aicostmanager/delivery/__init__.py
+++ b/aicostmanager/delivery/__init__.py
@@ -1,6 +1,6 @@
 from .base import Delivery, DeliveryType
 from .immediate import ImmediateDelivery
-from .mem_queue import MemQueueDelivery, get_global_delivery, get_global_delivery_health
+from .mem_queue import MemQueueDelivery
 from .persistent import PersistentDelivery
 
 __all__ = [
@@ -9,6 +9,4 @@ __all__ = [
     "ImmediateDelivery",
     "MemQueueDelivery",
     "PersistentDelivery",
-    "get_global_delivery",
-    "get_global_delivery_health",
 ]

--- a/aicostmanager/delivery/base.py
+++ b/aicostmanager/delivery/base.py
@@ -6,6 +6,11 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict
 
+import httpx
+from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_exponential_jitter
+
+from ..ini_manager import IniManager
+
 
 class DeliveryType(str, Enum):
     IMMEDIATE = "immediate"
@@ -19,19 +24,55 @@ class Delivery(ABC):
     def __init__(
         self,
         *,
+        ini_manager: IniManager | None = None,
+        aicm_api_key: str | None = None,
+        aicm_api_base: str | None = None,
+        aicm_api_url: str | None = None,
+        timeout: float = 10.0,
+        transport: httpx.BaseTransport | None = None,
+        endpoint: str = "/track",
+        body_key: str = "tracked",
         log_file: str | None = None,
         log_level: str | None = None,
         logger: logging.Logger | None = None,
     ) -> None:
-        log_file = log_file or os.getenv("AICM_DELIVERY_LOG_FILE")
-        log_level = (log_level or os.getenv("AICM_DELIVERY_LOG_LEVEL", "INFO")).upper()
-        self.logger = logger or logging.getLogger(self.__class__.__name__)
-        self.logger.setLevel(getattr(logging, log_level, logging.INFO))
-        if not self.logger.handlers:
-            handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler()
-            formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-            handler.setFormatter(formatter)
-            self.logger.addHandler(handler)
+        self.ini_manager = ini_manager or IniManager()
+        self.logger = logger or self.ini_manager.create_logger(
+            self.__class__.__name__,
+            log_file,
+            log_level,
+            "AICM_DELIVERY_LOG_FILE",
+            "AICM_DELIVERY_LOG_LEVEL",
+        )
+        self.api_key = aicm_api_key or os.getenv("AICM_API_KEY")
+        self.api_base = aicm_api_base or os.getenv("AICM_API_BASE", "https://aicostmanager.com")
+        self.api_url = aicm_api_url or os.getenv("AICM_API_URL", "/api/v1")
+        self.timeout = timeout
+        self._transport = transport
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+        self._endpoint = self.api_base.rstrip("/") + self.api_url.rstrip("/") + endpoint
+        self._body_key = body_key
+        self._headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "User-Agent": "aicostmanager-python",
+        }
+
+    def _post_with_retry(self, body: Dict[str, Any], *, max_attempts: int) -> httpx.Response:
+        def _retryable(exc: Exception) -> bool:
+            if isinstance(exc, httpx.HTTPStatusError):
+                return exc.response is None or exc.response.status_code >= 500
+            return True
+
+        for attempt in Retrying(
+            stop=stop_after_attempt(max_attempts),
+            wait=wait_exponential_jitter(),
+            retry=retry_if_exception(_retryable),
+        ):
+            with attempt:
+                resp = self._client.post(self._endpoint, json=body, headers=self._headers)
+                resp.raise_for_status()
+                return resp
+        raise RuntimeError("unreachable")
 
     @abstractmethod
     def enqueue(self, payload: Dict[str, Any]) -> None:

--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-import os
 import httpx
-from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
 from .base import Delivery
+from ..ini_manager import IniManager
 
 
 class ImmediateDelivery(Delivery):
@@ -20,40 +19,25 @@ class ImmediateDelivery(Delivery):
         aicm_api_url: Optional[str] = None,
         timeout: float = 10.0,
         transport: httpx.BaseTransport | None = None,
+        ini_manager: IniManager | None = None,
         log_file: str | None = None,
         log_level: str | None = None,
     ) -> None:
-        super().__init__(log_file=log_file, log_level=log_level)
-        self.api_key = aicm_api_key or os.getenv("AICM_API_KEY")
-        self.api_base = aicm_api_base or os.getenv("AICM_API_BASE", "https://aicostmanager.com")
-        self.api_url = aicm_api_url or os.getenv("AICM_API_URL", "/api/v1")
-        self.timeout = timeout
-        self._transport = transport
-        self._client = httpx.Client(timeout=timeout, transport=transport)
-        self._endpoint = self.api_base.rstrip("/") + self.api_url.rstrip("/") + "/track"
-        self._headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "User-Agent": "aicostmanager-python",
-        }
+        super().__init__(
+            ini_manager=ini_manager,
+            aicm_api_key=aicm_api_key,
+            aicm_api_base=aicm_api_base,
+            aicm_api_url=aicm_api_url,
+            timeout=timeout,
+            transport=transport,
+            log_file=log_file,
+            log_level=log_level,
+        )
 
     def enqueue(self, payload: Dict[str, Any]) -> None:
-        body = {"tracked": [payload]}
-
-        def _retryable(exc: Exception) -> bool:
-            if isinstance(exc, httpx.HTTPStatusError):
-                return exc.response is None or exc.response.status_code >= 500
-            return True
-
+        body = {self._body_key: [payload]}
         try:
-            for attempt in Retrying(
-                stop=stop_after_attempt(3),
-                wait=wait_exponential_jitter(),
-                retry=retry_if_exception(_retryable),
-            ):
-                with attempt:
-                    resp = self._client.post(self._endpoint, json=body, headers=self._headers)
-                    resp.raise_for_status()
-                    return None
+            self._post_with_retry(body, max_attempts=3)
         except Exception as exc:
             self.logger.exception("Immediate delivery failed: %s", exc)
             raise

--- a/aicostmanager/ini_manager.py
+++ b/aicostmanager/ini_manager.py
@@ -1,151 +1,78 @@
 from __future__ import annotations
 
-import configparser
 import json
+import logging
 import os
-import tempfile
-import time
-from contextlib import contextmanager
+from pathlib import Path
 
-
-@contextmanager
-def _file_lock(file_path: str):
-    """Context manager for file locking to prevent race conditions."""
-    if not file_path:
-        yield
-        return
-    lock_file = f"{file_path}.lock"
-    dir_path = os.path.dirname(file_path)
-    if dir_path:
-        os.makedirs(dir_path, exist_ok=True)
-    max_retries = 10
-    retry_delay = 0.1
-    for attempt in range(max_retries):
-        try:
-            lock_fd = os.open(lock_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            break
-        except FileExistsError:
-            if attempt == max_retries - 1:
-                try:
-                    stat = os.stat(lock_file)
-                    if time.time() - stat.st_mtime > 30:
-                        os.unlink(lock_file)
-                        continue
-                except (OSError, FileNotFoundError):
-                    pass
-                raise RuntimeError(f"Could not acquire lock for {file_path}")
-            time.sleep(retry_delay * (2 ** attempt))
-    try:
-        yield
-    finally:
-        try:
-            os.close(lock_fd)
-            os.unlink(lock_file)
-        except (OSError, FileNotFoundError):
-            pass
-
-
-def _safe_read_config(ini_path: str) -> configparser.ConfigParser:
-    config = configparser.ConfigParser(allow_no_value=True, strict=False)
-    if not os.path.exists(ini_path):
-        return config
-    try:
-        config.read(ini_path)
-        return config
-    except configparser.DuplicateSectionError:
-        _clean_duplicate_sections(ini_path)
-        config = configparser.ConfigParser(allow_no_value=True, strict=False)
-        config.read(ini_path)
-        return config
-
-
-def _clean_duplicate_sections(ini_path: str) -> None:
-    if not os.path.exists(ini_path):
-        return
-    seen_sections: set[str] = set()
-    cleaned_lines: list[str] = []
-    current_section: str | None = None
-    section_content: list[str] = []
-    with open(ini_path, "r") as f:
-        lines = f.readlines()
-    for line in lines:
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            if current_section is not None:
-                if current_section not in seen_sections:
-                    cleaned_lines.extend(section_content)
-                    seen_sections.add(current_section)
-                section_content = []
-            current_section = stripped
-            section_content = [line]
-        else:
-            section_content.append(line)
-    if current_section is not None and current_section not in seen_sections:
-        cleaned_lines.extend(section_content)
-    _atomic_write(ini_path, "".join(cleaned_lines))
-
-
-def _atomic_write(file_path: str, content: str) -> None:
-    if not file_path:
-        return
-    dir_path = os.path.dirname(file_path)
-    if dir_path:
-        os.makedirs(dir_path, exist_ok=True)
-    temp_dir = dir_path if dir_path else "."
-    temp_fd, temp_path = tempfile.mkstemp(dir=temp_dir, prefix=f".{os.path.basename(file_path)}.tmp")
-    try:
-        with os.fdopen(temp_fd, "w") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        os.rename(temp_path, file_path)
-    except Exception:
-        try:
-            os.unlink(temp_path)
-        except (OSError, FileNotFoundError):
-            pass
-        raise
-
+from .utils.ini_utils import atomic_write, file_lock, safe_read_config
 
 
 class IniManager:
     """Handle reading and writing triggered limits to the INI file."""
 
-    def __init__(self, ini_path: str) -> None:
-        self.ini_path = ini_path
-        with _file_lock(self.ini_path):
-            self._config = _safe_read_config(self.ini_path)
+    def __init__(self, ini_path: str | None = None) -> None:
+        self.ini_path = self.resolve_path(ini_path)
+        with file_lock(self.ini_path):
+            self._config = safe_read_config(self.ini_path)
+
+    @staticmethod
+    def create_logger(
+        name: str,
+        log_file: str | None = None,
+        log_level: str | None = None,
+        log_file_env: str = "AICM_LOG_FILE",
+        log_level_env: str = "AICM_LOG_LEVEL",
+    ) -> logging.Logger:
+        """Return a configured :class:`logging.Logger`."""
+        log_file = log_file or os.getenv(log_file_env)
+        level = (log_level or os.getenv(log_level_env, "INFO")).upper()
+        logger = logging.getLogger(name)
+        logger.setLevel(getattr(logging, level, logging.INFO))
+        if not logger.handlers:
+            handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler()
+            formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        return logger
+
+    @classmethod
+    def resolve_path(cls, ini_path: str | None = None) -> str:
+        """Resolve the path to the INI file."""
+        return ini_path or os.getenv(
+            "AICM_INI_PATH", str(Path.home() / ".config" / "aicostmanager" / "AICM.INI")
+        )
 
     def _write(self) -> None:
-        with _file_lock(self.ini_path):
+        with file_lock(self.ini_path):
             import io
             content = io.StringIO()
             self._config.write(content)
-            _atomic_write(self.ini_path, content.getvalue())
+            atomic_write(self.ini_path, content.getvalue())
 
     def get_option(self, section: str, option: str, fallback: str | None = None) -> str | None:
         """Return ``option`` from ``section`` or ``fallback`` when missing."""
-        with _file_lock(self.ini_path):
-            config = _safe_read_config(self.ini_path)
+        with file_lock(self.ini_path):
+            config = safe_read_config(self.ini_path)
         if config.has_section(section) and option in config[section]:
             return config[section][option]
         return fallback
 
     def set_option(self, section: str, option: str, value: str) -> None:
         """Persist ``option`` under ``section`` with ``value``."""
-        with _file_lock(self.ini_path):
-            cfg = _safe_read_config(self.ini_path)
+        with file_lock(self.ini_path):
+            cfg = safe_read_config(self.ini_path)
             if section not in cfg:
                 cfg.add_section(section)
             cfg[section][option] = str(value)
             import io
             buf = io.StringIO()
             cfg.write(buf)
-            _atomic_write(self.ini_path, buf.getvalue())
+            atomic_write(self.ini_path, buf.getvalue())
 
     def read_triggered_limits(self) -> dict:
-        with _file_lock(self.ini_path):
-            self._config = _safe_read_config(self.ini_path)
+        with file_lock(self.ini_path):
+            self._config = safe_read_config(self.ini_path)
         if (
             "triggered_limits" not in self._config
             or "payload" not in self._config["triggered_limits"]

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -15,7 +15,7 @@ from .client import (
     UsageLimitExceeded,
 )
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
-from .delivery import MemQueueDelivery, get_global_delivery
+from .delivery import MemQueueDelivery
 from .universal_extractor import UniversalExtractor
 
 _HTTP_METHODS = {
@@ -78,7 +78,7 @@ class RestCostManager:
         if delivery is not None:
             self.delivery = delivery
         else:
-            self.delivery = get_global_delivery(
+            self.delivery = MemQueueDelivery(
                 aicm_api_key=aicm_api_key,
                 aicm_api_base=aicm_api_base,
                 aicm_api_url=aicm_api_url,

--- a/aicostmanager/triggered_limit_manager.py
+++ b/aicostmanager/triggered_limit_manager.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
 import jwt
 
 from .client import CostManagerClient
-from .models import UsageLimitIn, UsageLimitOut, UsageLimitProgressOut
 from .ini_manager import IniManager
 
 
-class LimitsManager:
+class TriggeredLimitManager:
     """Manage triggered limits fetched from the API and stored locally."""
 
     def __init__(self, client: CostManagerClient, ini_manager: IniManager | None = None) -> None:
@@ -23,7 +22,6 @@ class LimitsManager:
             return None
 
     def update_triggered_limits(self) -> None:
-        """Fetch triggered limits from the API and persist them to the INI file."""
         data = self.client.get_triggered_limits() or {}
         if isinstance(data, dict):
             tl_data = data.get("triggered_limits", data)
@@ -37,7 +35,6 @@ class LimitsManager:
         service_key: Optional[str] = None,
         client_customer_key: Optional[str] = None,
     ) -> List[dict]:
-        """Return triggered limit events matching the provided parameters."""
         tl_raw = self.ini_manager.read_triggered_limits()
         token = tl_raw.get("encrypted_payload")
         public_key = tl_raw.get("public_key")
@@ -52,31 +49,7 @@ class LimitsManager:
                 continue
             if service_key and event.get("service_key") != service_key:
                 continue
-            if (
-                client_customer_key
-                and event.get("client_customer_key") != client_customer_key
-            ):
+            if client_customer_key and event.get("client_customer_key") != client_customer_key:
                 continue
             results.append(event)
         return results
-
-    # Usage limit management methods
-    def list_usage_limits(self) -> Iterable[UsageLimitOut]:
-        return list(self.client.list_usage_limits())
-
-    def create_usage_limit(self, data: UsageLimitIn | dict) -> UsageLimitOut:
-        return self.client.create_usage_limit(data)
-
-    def get_usage_limit(self, limit_id: str) -> UsageLimitOut:
-        return self.client.get_usage_limit(limit_id)
-
-    def update_usage_limit(
-        self, limit_id: str, data: UsageLimitIn | dict
-    ) -> UsageLimitOut:
-        return self.client.update_usage_limit(limit_id, data)
-
-    def delete_usage_limit(self, limit_id: str) -> None:
-        self.client.delete_usage_limit(limit_id)
-
-    def list_usage_limit_progress(self) -> Iterable[UsageLimitProgressOut]:
-        return list(self.client.list_usage_limit_progress())

--- a/aicostmanager/usage_limit_manager.py
+++ b/aicostmanager/usage_limit_manager.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .client import CostManagerClient
+from .models import UsageLimitIn, UsageLimitOut, UsageLimitProgressOut
+
+
+class UsageLimitManager:
+    """Manage usage limits via the :class:`CostManagerClient`."""
+
+    def __init__(self, client: CostManagerClient) -> None:
+        self.client = client
+
+    def list_usage_limits(self) -> Iterable[UsageLimitOut]:
+        return list(self.client.list_usage_limits())
+
+    def create_usage_limit(self, data: UsageLimitIn | dict) -> UsageLimitOut:
+        return self.client.create_usage_limit(data)
+
+    def get_usage_limit(self, limit_id: str) -> UsageLimitOut:
+        return self.client.get_usage_limit(limit_id)
+
+    def update_usage_limit(self, limit_id: str, data: UsageLimitIn | dict) -> UsageLimitOut:
+        return self.client.update_usage_limit(limit_id, data)
+
+    def delete_usage_limit(self, limit_id: str) -> None:
+        self.client.delete_usage_limit(limit_id)
+
+    def list_usage_limit_progress(self) -> Iterable[UsageLimitProgressOut]:
+        return list(self.client.list_usage_limit_progress())

--- a/aicostmanager/utils/ini_utils.py
+++ b/aicostmanager/utils/ini_utils.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import configparser
+import os
+import tempfile
+import time
+from contextlib import contextmanager
+
+
+@contextmanager
+def file_lock(file_path: str):
+    """Context manager for file locking to prevent race conditions."""
+    if not file_path:
+        yield
+        return
+    lock_file = f"{file_path}.lock"
+    dir_path = os.path.dirname(file_path)
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+    max_retries = 10
+    retry_delay = 0.1
+    for attempt in range(max_retries):
+        try:
+            lock_fd = os.open(lock_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            break
+        except FileExistsError:
+            if attempt == max_retries - 1:
+                try:
+                    stat = os.stat(lock_file)
+                    if time.time() - stat.st_mtime > 30:
+                        os.unlink(lock_file)
+                        continue
+                except (OSError, FileNotFoundError):
+                    pass
+                raise RuntimeError(f"Could not acquire lock for {file_path}")
+            time.sleep(retry_delay * (2 ** attempt))
+    try:
+        yield
+    finally:
+        try:
+            os.close(lock_fd)
+            os.unlink(lock_file)
+        except (OSError, FileNotFoundError):
+            pass
+
+
+def safe_read_config(ini_path: str) -> configparser.ConfigParser:
+    config = configparser.ConfigParser(allow_no_value=True, strict=False)
+    if not os.path.exists(ini_path):
+        return config
+    try:
+        config.read(ini_path)
+        return config
+    except configparser.DuplicateSectionError:
+        clean_duplicate_sections(ini_path)
+        config = configparser.ConfigParser(allow_no_value=True, strict=False)
+        config.read(ini_path)
+        return config
+
+
+def clean_duplicate_sections(ini_path: str) -> None:
+    if not os.path.exists(ini_path):
+        return
+    seen_sections: set[str] = set()
+    cleaned_lines: list[str] = []
+    current_section: str | None = None
+    section_content: list[str] = []
+    with open(ini_path, "r") as f:
+        lines = f.readlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if current_section is not None:
+                if current_section not in seen_sections:
+                    cleaned_lines.extend(section_content)
+                    seen_sections.add(current_section)
+                section_content = []
+            current_section = stripped
+            section_content = [line]
+        else:
+            section_content.append(line)
+    if current_section is not None and current_section not in seen_sections:
+        cleaned_lines.extend(section_content)
+    atomic_write(ini_path, "".join(cleaned_lines))
+
+
+def atomic_write(file_path: str, content: str) -> None:
+    if not file_path:
+        return
+    dir_path = os.path.dirname(file_path)
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+    temp_dir = dir_path if dir_path else "."
+    temp_fd, temp_path = tempfile.mkstemp(dir=temp_dir, prefix=f".{os.path.basename(file_path)}.tmp")
+    try:
+        with os.fdopen(temp_fd, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(temp_path, file_path)
+    except Exception:
+        try:
+            os.unlink(temp_path)
+        except (OSError, FileNotFoundError):
+            pass
+        raise

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,6 @@ Overflow behavior when the queue is full:
 - `raise`: raise `queue.Full`
 - `backpressure` (default): drop the oldest payload; increments `total_discarded` and optionally invokes `on_discard`
 
-Inspect metrics using `get_global_delivery_health()`.
+Inspect metrics using the delivery instance's `stats()` method.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 - [Manual Usage Tracking](tracker.md) - Record custom usage events
 - [REST API Tracking](rest.md) - Wrap requests or httpx sessions
 - [Configuration & Env Vars](configuration.md) - Environment variables and INI behavior
-- [Limits Management](limits_manager.md) - Manage usage limits and triggered limits
+- [Limit Managers](limit_managers.md) - Manage usage limits and triggered limits
 
 ## Development
 

--- a/docs/limit_managers.md
+++ b/docs/limit_managers.md
@@ -1,26 +1,24 @@
-# Limits Manager
+# Limit Managers
 
-The `LimitsManager` wraps the AICostManager usage limit endpoints and
-provides convenience helpers for working with both configured limits and
-triggered limit events stored in the local `AICM.ini` file.
+The library provides separate managers for usage limits and triggered limit
+notifications.
 
 ## Managing Usage Limits
 
-Usage limits can be scoped to a team, individual user or a specific API
-key.  Create and manage limits through the manager which delegates to the
-underlying :class:`~aicostmanager.client.CostManagerClient`.
+Use the :class:`UsageLimitManager` to create and maintain limits via the
+API:
 
 ```python
 from aicostmanager import (
     CostManagerClient,
-    LimitsManager,
+    UsageLimitManager,
     UsageLimitIn,
     ThresholdType,
     Period,
 )
 
 client = CostManagerClient(aicm_api_key="sk-test")
-limits = LimitsManager(client)
+limits = UsageLimitManager(client)
 
 # Create a monthly team limit
 limit = limits.create_usage_limit(
@@ -56,15 +54,21 @@ limits.delete_usage_limit(limit.uuid)
 
 ## Working with Triggered Limits
 
-The manager can also cache triggered limit events in the INI file so they
-can be checked locally without another API call.
+Triggered limit events can be cached locally using the
+:class:`TriggeredLimitManager` so they can be checked without an additional
+API call:
 
 ```python
+from aicostmanager import CostManagerClient, TriggeredLimitManager
+
+client = CostManagerClient(aicm_api_key="sk-test")
+tl_mgr = TriggeredLimitManager(client)
+
 # Refresh the local cache of triggered limits
-limits.update_triggered_limits()
+tl_mgr.update_triggered_limits()
 
 # Filter triggered events for an API key and service
-events = limits.check_triggered_limits(
+events = tl_mgr.check_triggered_limits(
     api_key_id="550e8400-e29b-41d4-a716-446655440000",
     service_key="openai::gpt-4",
 )

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -102,13 +102,11 @@ async with AsyncCostManagerClient() as client:
 ```
 ## Health & Metrics
 
-Use the helper to inspect queue state and metrics such as total sent, failed,
-and discarded payloads:
+Call the ``stats`` method on the delivery instance to inspect queue state and
+metrics such as total sent, failed, and discarded payloads:
 
 ```python
-from aicostmanager import get_global_delivery_health
-
-print(get_global_delivery_health())
+print(tracker.delivery.stats())
 ```
 
 ## Multiprocessing Environments

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,8 +87,7 @@ When recording custom usage with :class:`Tracker` in a FastAPI application,
 create the tracker during application startup so configuration loading doesn't
 block individual requests. The asynchronous factory ``Tracker.create_async``
 performs the initialization in a thread and returns a ready instance. During
-shutdown, stop the background delivery using ``Tracker.close`` (or
-``get_global_delivery(...).stop()`` if calling the delivery queue directly):
+shutdown, stop the background delivery using ``Tracker.close``:
 
 ```python
 from fastapi import FastAPI

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,28 +106,6 @@ def aicm_ini_path(tmp_path_factory):
 
 
 @pytest.fixture
-def clean_delivery():
-    """Reset global delivery state before each test to avoid pollution between tests."""
-    from aicostmanager import delivery as mod
-
-    # Store the current state
-    original_delivery = getattr(mod, "_global_delivery", None)
-
-    # Reset to clean state
-    mod._global_delivery = None
-
-    yield
-
-    # Cleanup: stop any running delivery and reset
-    if mod._global_delivery is not None:
-        try:
-            mod._global_delivery.stop()
-        except Exception:
-            pass
-        mod._global_delivery = None
-
-
-@pytest.fixture
 def clear_triggered_limits(aicm_ini_path):
     """Clear triggered limits from the INI file to prevent test interference from usage limits."""
     import configparser


### PR DESCRIPTION
## Summary
- centralize HTTP client, endpoint, headers and retry logic in base Delivery
- add reusable logger and path helpers via IniManager
- split LimitsManager into TriggeredLimitManager and UsageLimitManager
- remove global MemQueueDelivery singleton and dead imports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_b_68a306c9c928832ba8a33bd56e62d24a