### PR TITLE
Refactor delivery subsystem and reorganize limit managers

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -15,6 +15,7 @@ from .config_manager import CostManagerConfig
 from .cost_manager import CostManager
 from .delivery import (
     Delivery,
+    DeliveryConfig,
     DeliveryType,
     ImmediateDelivery,
     MemQueueDelivery,
@@ -49,8 +50,7 @@ from .models import (
 from .rest_cost_manager import AsyncRestCostManager, RestCostManager
 from .tracker import Tracker
 from .universal_extractor import UniversalExtractor
-from .triggered_limit_manager import TriggeredLimitManager
-from .usage_limit_manager import UsageLimitManager
+from .limits import BaseLimitManager, TriggeredLimitManager, UsageLimitManager
 
 __all__ = [
     "AICMError",
@@ -67,10 +67,12 @@ __all__ = [
     "UniversalExtractor",
     "Delivery",
     "DeliveryType",
+    "DeliveryConfig",
     "ImmediateDelivery",
     "MemQueueDelivery",
     "PersistentDelivery",
     "Tracker",
+    "BaseLimitManager",
     "TriggeredLimitManager",
     "UsageLimitManager",
     "ApiUsageRecord",

--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 from .client import CostManagerClient, UsageLimitExceeded
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
-from .delivery import MemQueueDelivery
+from .delivery import DeliveryConfig, MemQueueDelivery
 from .universal_extractor import UniversalExtractor
 
 
@@ -61,11 +61,14 @@ class CostManager:
         if delivery is not None:
             self.delivery = delivery
         else:
-            self.delivery = MemQueueDelivery(
+            cfg = DeliveryConfig(
                 aicm_api_key=aicm_api_key,
                 aicm_api_base=aicm_api_base,
                 aicm_api_url=aicm_api_url,
                 timeout=delivery_timeout,
+            )
+            self.delivery = MemQueueDelivery(
+                cfg,
                 max_retries=delivery_max_retries,
                 queue_size=delivery_queue_size,
                 batch_interval=delivery_batch_interval or 0.05,

--- a/aicostmanager/delivery/__init__.py
+++ b/aicostmanager/delivery/__init__.py
@@ -1,12 +1,14 @@
-from .base import Delivery, DeliveryType
+from .base import Delivery, DeliveryConfig, DeliveryType, QueueDelivery
 from .immediate import ImmediateDelivery
 from .mem_queue import MemQueueDelivery
 from .persistent import PersistentDelivery
 
 __all__ = [
     "Delivery",
+    "DeliveryConfig",
     "DeliveryType",
     "ImmediateDelivery",
     "MemQueueDelivery",
     "PersistentDelivery",
+    "QueueDelivery",
 ]

--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -1,38 +1,17 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-import httpx
-
-from .base import Delivery
-from ..ini_manager import IniManager
+from .base import Delivery, DeliveryConfig, DeliveryType
 
 
 class ImmediateDelivery(Delivery):
     """Synchronous delivery using direct HTTP requests with retries."""
 
-    def __init__(
-        self,
-        *,
-        aicm_api_key: Optional[str] = None,
-        aicm_api_base: Optional[str] = None,
-        aicm_api_url: Optional[str] = None,
-        timeout: float = 10.0,
-        transport: httpx.BaseTransport | None = None,
-        ini_manager: IniManager | None = None,
-        log_file: str | None = None,
-        log_level: str | None = None,
-    ) -> None:
-        super().__init__(
-            ini_manager=ini_manager,
-            aicm_api_key=aicm_api_key,
-            aicm_api_base=aicm_api_base,
-            aicm_api_url=aicm_api_url,
-            timeout=timeout,
-            transport=transport,
-            log_file=log_file,
-            log_level=log_level,
-        )
+    type = DeliveryType.IMMEDIATE
+
+    def __init__(self, config: DeliveryConfig) -> None:
+        super().__init__(config)
 
     def enqueue(self, payload: Dict[str, Any]) -> None:
         body = {self._body_key: [payload]}

--- a/aicostmanager/ini_manager.py
+++ b/aicostmanager/ini_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 from pathlib import Path
 
@@ -15,26 +14,6 @@ class IniManager:
         self.ini_path = self.resolve_path(ini_path)
         with file_lock(self.ini_path):
             self._config = safe_read_config(self.ini_path)
-
-    @staticmethod
-    def create_logger(
-        name: str,
-        log_file: str | None = None,
-        log_level: str | None = None,
-        log_file_env: str = "AICM_LOG_FILE",
-        log_level_env: str = "AICM_LOG_LEVEL",
-    ) -> logging.Logger:
-        """Return a configured :class:`logging.Logger`."""
-        log_file = log_file or os.getenv(log_file_env)
-        level = (log_level or os.getenv(log_level_env, "INFO")).upper()
-        logger = logging.getLogger(name)
-        logger.setLevel(getattr(logging, level, logging.INFO))
-        if not logger.handlers:
-            handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler()
-            formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-        return logger
 
     @classmethod
     def resolve_path(cls, ini_path: str | None = None) -> str:

--- a/aicostmanager/limits/__init__.py
+++ b/aicostmanager/limits/__init__.py
@@ -1,0 +1,9 @@
+from .base import BaseLimitManager
+from .triggered import TriggeredLimitManager
+from .usage import UsageLimitManager
+
+__all__ = [
+    "BaseLimitManager",
+    "TriggeredLimitManager",
+    "UsageLimitManager",
+]

--- a/aicostmanager/limits/base.py
+++ b/aicostmanager/limits/base.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from ..client import CostManagerClient
+
+
+class BaseLimitManager:
+    """Common base class for limit managers."""
+
+    def __init__(self, client: CostManagerClient) -> None:
+        self.client = client

--- a/aicostmanager/limits/triggered.py
+++ b/aicostmanager/limits/triggered.py
@@ -4,15 +4,16 @@ from typing import List, Optional
 
 import jwt
 
-from .client import CostManagerClient
-from .ini_manager import IniManager
+from ..client import CostManagerClient
+from ..ini_manager import IniManager
+from .base import BaseLimitManager
 
 
-class TriggeredLimitManager:
+class TriggeredLimitManager(BaseLimitManager):
     """Manage triggered limits fetched from the API and stored locally."""
 
     def __init__(self, client: CostManagerClient, ini_manager: IniManager | None = None) -> None:
-        self.client = client
+        super().__init__(client)
         self.ini_manager = ini_manager or IniManager(client.ini_path)
 
     def _decode(self, token: str, public_key: str) -> Optional[dict]:

--- a/aicostmanager/limits/usage.py
+++ b/aicostmanager/limits/usage.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from .client import CostManagerClient
-from .models import UsageLimitIn, UsageLimitOut, UsageLimitProgressOut
+from ..client import CostManagerClient
+from ..models import UsageLimitIn, UsageLimitOut, UsageLimitProgressOut
+from .base import BaseLimitManager
 
 
-class UsageLimitManager:
+class UsageLimitManager(BaseLimitManager):
     """Manage usage limits via the :class:`CostManagerClient`."""
-
-    def __init__(self, client: CostManagerClient) -> None:
-        self.client = client
 
     def list_usage_limits(self) -> Iterable[UsageLimitOut]:
         return list(self.client.list_usage_limits())

--- a/aicostmanager/logger.py
+++ b/aicostmanager/logger.py
@@ -1,0 +1,26 @@
+"""Logging utilities for aicostmanager."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+
+def create_logger(
+    name: str,
+    log_file: str | None = None,
+    log_level: str | None = None,
+    log_file_env: str = "AICM_LOG_FILE",
+    log_level_env: str = "AICM_LOG_LEVEL",
+) -> logging.Logger:
+    """Return a configured :class:`logging.Logger`."""
+    log_file = log_file or os.getenv(log_file_env)
+    level = (log_level or os.getenv(log_level_env, "INFO")).upper()
+    logger = logging.getLogger(name)
+    logger.setLevel(getattr(logging, level, logging.INFO))
+    if not logger.handlers:
+        handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler()
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -15,7 +15,7 @@ from .client import (
     UsageLimitExceeded,
 )
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
-from .delivery import MemQueueDelivery
+from .delivery import DeliveryConfig, MemQueueDelivery
 from .universal_extractor import UniversalExtractor
 
 _HTTP_METHODS = {
@@ -78,11 +78,14 @@ class RestCostManager:
         if delivery is not None:
             self.delivery = delivery
         else:
-            self.delivery = MemQueueDelivery(
+            cfg = DeliveryConfig(
                 aicm_api_key=aicm_api_key,
                 aicm_api_base=aicm_api_base,
                 aicm_api_url=aicm_api_url,
                 timeout=delivery_timeout,
+            )
+            self.delivery = MemQueueDelivery(
+                cfg,
                 max_retries=delivery_max_retries,
                 queue_size=delivery_queue_size,
                 batch_interval=delivery_batch_interval or 0.05,

--- a/tests/test_limits_manager.py
+++ b/tests/test_limits_manager.py
@@ -4,8 +4,7 @@ import jwt
 
 from aicostmanager.client import CostManagerClient
 from aicostmanager.ini_manager import IniManager
-from aicostmanager.triggered_limit_manager import TriggeredLimitManager
-from aicostmanager.usage_limit_manager import UsageLimitManager
+from aicostmanager.limits import TriggeredLimitManager, UsageLimitManager
 from aicostmanager.models import (
     UsageLimitIn,
     UsageLimitOut,


### PR DESCRIPTION
## Summary
- add DeliveryConfig and QueueDelivery to reduce duplication across delivery implementations
- provide factory-based tracker construction and optional delivery injection
- move logging helper to dedicated module and reorganize limit managers under `limits`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68a30a75a1bc832b85a0f055c443f43f