### PR TITLE
Allow shared IniManager for deliveries

### DIFF
--- a/aicostmanager/cost_manager.py
+++ b/aicostmanager/cost_manager.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 from .client import CostManagerClient, UsageLimitExceeded
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
 from .delivery import DeliveryConfig, MemQueueDelivery
+from .ini_manager import IniManager
 from .universal_extractor import UniversalExtractor
 
 
@@ -62,6 +63,7 @@ class CostManager:
             self.delivery = delivery
         else:
             cfg = DeliveryConfig(
+                ini_manager=IniManager(self.cm_client.ini_path),
                 aicm_api_key=aicm_api_key,
                 aicm_api_base=aicm_api_base,
                 aicm_api_url=aicm_api_url,

--- a/aicostmanager/delivery/base.py
+++ b/aicostmanager/delivery/base.py
@@ -25,12 +25,12 @@ class DeliveryType(str, Enum):
 class DeliveryConfig:
     """Common configuration shared by delivery implementations."""
 
+    ini_manager: IniManager
     aicm_api_key: str | None = None
     aicm_api_base: str | None = None
     aicm_api_url: str | None = None
     timeout: float = 10.0
     transport: httpx.BaseTransport | None = None
-    ini_manager: IniManager | None = None
     log_file: str | None = None
     log_level: str | None = None
 
@@ -46,7 +46,9 @@ class Delivery(ABC):
         body_key: str = "tracked",
         logger: logging.Logger | None = None,
     ) -> None:
-        self.ini_manager = config.ini_manager or IniManager()
+        if config.ini_manager is None:
+            raise ValueError("ini_manager must be provided")
+        self.ini_manager = config.ini_manager
         self.logger = logger or create_logger(
             self.__class__.__name__,
             config.log_file,

--- a/aicostmanager/delivery/persistent.py
+++ b/aicostmanager/delivery/persistent.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import DeliveryConfig, DeliveryType, QueueDelivery
-from ..ini_manager import IniManager
 
 
 class PersistentDelivery(QueueDelivery):
@@ -24,7 +23,6 @@ class PersistentDelivery(QueueDelivery):
         self,
         *,
         config: DeliveryConfig,
-        aicm_ini_path: Optional[str] = None,
         db_path: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
         poll_interval: float = 1.0,
@@ -32,23 +30,10 @@ class PersistentDelivery(QueueDelivery):
         max_attempts: int = 3,
         max_retries: int = 5,
         log_bodies: bool = False,
-        ini_manager: IniManager | None = None,
         **kwargs: Any,
     ) -> None:
-        ini_path = IniManager.resolve_path(aicm_ini_path)
-        ini_manager = ini_manager or config.ini_manager or IniManager(ini_path)
-        cfg = DeliveryConfig(
-            aicm_api_key=config.aicm_api_key,
-            aicm_api_base=config.aicm_api_base,
-            aicm_api_url=config.aicm_api_url,
-            timeout=config.timeout,
-            transport=config.transport,
-            ini_manager=ini_manager,
-            log_file=config.log_file,
-            log_level=config.log_level,
-        )
         super().__init__(
-            cfg,
+            config,
             batch_interval=batch_interval,
             max_batch_size=kwargs.get("max_batch_size", 100),
             max_retries=max_retries,

--- a/aicostmanager/rest_cost_manager.py
+++ b/aicostmanager/rest_cost_manager.py
@@ -16,6 +16,7 @@ from .client import (
 )
 from .config_manager import Config, CostManagerConfig, TriggeredLimit
 from .delivery import DeliveryConfig, MemQueueDelivery
+from .ini_manager import IniManager
 from .universal_extractor import UniversalExtractor
 
 _HTTP_METHODS = {
@@ -79,6 +80,7 @@ class RestCostManager:
             self.delivery = delivery
         else:
             cfg = DeliveryConfig(
+                ini_manager=IniManager(self.cm_client.ini_path),
                 aicm_api_key=aicm_api_key,
                 aicm_api_base=aicm_api_base,
                 aicm_api_url=aicm_api_url,

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -4,6 +4,7 @@ import json
 import httpx
 
 from aicostmanager import Tracker
+from aicostmanager.ini_manager import IniManager
 
 
 def test_tracker_builds_record():
@@ -14,7 +15,7 @@ def test_tracker_builds_record():
         return httpx.Response(200, json={"ok": True})
 
     transport = httpx.MockTransport(handler)
-    tracker = Tracker(aicm_api_key="test", transport=transport)
+    tracker = Tracker(aicm_api_key="test", transport=transport, ini_manager=IniManager("ini"))
     tracker.track("openai", "gpt-5-mini", {"input_tokens": 1}, client_customer_key="abc")
     tracker.close()
     assert received
@@ -32,7 +33,7 @@ def test_tracker_track_async():
         return httpx.Response(200, json={"ok": True})
 
     transport = httpx.MockTransport(handler)
-    tracker = Tracker(aicm_api_key="test", transport=transport)
+    tracker = Tracker(aicm_api_key="test", transport=transport, ini_manager=IniManager("ini"))
 
     async def run():
         await tracker.track_async("openai", "gpt-5-mini", {"input_tokens": 1})


### PR DESCRIPTION
## Summary
- accept an IniManager instance in Tracker and forward to delivery implementations
- require delivery classes to use provided IniManager instead of resolving paths
- update cost manager wrappers and tests to supply a shared IniManager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_tracker.py tests/test_delivery_manager.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68a31463b9dc832b93a90c7d41df53ea