### PR TITLE
Add tests and docs for delivery queues

### DIFF
--- a/docs/persistent_delivery.md
+++ b/docs/persistent_delivery.md
@@ -32,14 +32,13 @@ from aicostmanager import PersistentDelivery
 payload = {"api_id": "openai", "service_key": "gpt", "payload": {"tokens": 1}}
 
 delivery = PersistentDelivery(aicm_api_key="sk-test", batch_interval=0.5)
-delivery.enqueue(payload)             # queued for background delivery
-delivery.deliver_now(payload)         # immediate delivery of a single record
+delivery.enqueue(payload)             # queue for background delivery
 ```
 
-The queue can be inspected for health information:
+The queue can be inspected for runtime statistics:
 
 ```python
-stats = delivery.health()
+stats = delivery.stats()
 print(stats)
 ```
 

--- a/tests/test_mem_queue_delivery.py
+++ b/tests/test_mem_queue_delivery.py
@@ -1,0 +1,40 @@
+import time
+
+import httpx
+
+from aicostmanager.delivery import DeliveryConfig, MemQueueDelivery
+from aicostmanager.ini_manager import IniManager
+
+
+def test_mem_queue_delivery_sends_and_tracks_stats(tmp_path):
+    sent = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sent.append(request.json())
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    cfg = DeliveryConfig(
+        ini_manager=IniManager(str(tmp_path / "aicm.ini")),
+        aicm_api_key="sk-test",
+        aicm_api_base="https://example.com",
+        aicm_api_url="",
+        transport=transport,
+    )
+    delivery = MemQueueDelivery(
+        cfg, batch_interval=0.01, max_batch_size=10, max_attempts=1
+    )
+    payload = {"foo": "bar"}
+    delivery.enqueue(payload)
+
+    for _ in range(100):
+        if delivery.stats()["queued"] == 0:
+            break
+        time.sleep(0.02)
+    delivery.stop()
+
+    assert sent and sent[0]["tracked"][0] == payload
+    stats = delivery.stats()
+    assert stats["queued"] == 0
+    assert stats["total_sent"] == 1
+    assert stats["total_failed"] == 0

--- a/tests/test_persistent_delivery.py
+++ b/tests/test_persistent_delivery.py
@@ -1,0 +1,45 @@
+import time
+
+import httpx
+
+from aicostmanager.delivery import DeliveryConfig, PersistentDelivery
+from aicostmanager.ini_manager import IniManager
+
+
+def test_persistent_delivery_sends_and_tracks_stats(tmp_path):
+    sent = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sent.append(request.json())
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    cfg = DeliveryConfig(
+        ini_manager=IniManager(str(tmp_path / "aicm.ini")),
+        aicm_api_key="sk-test",
+        aicm_api_base="https://example.com",
+        aicm_api_url="",
+        transport=transport,
+    )
+    delivery = PersistentDelivery(
+        config=cfg,
+        db_path=str(tmp_path / "queue.db"),
+        poll_interval=0.01,
+        batch_interval=0.01,
+        max_attempts=1,
+        max_batch_size=10,
+    )
+    payload = {"foo": "bar"}
+    delivery.enqueue(payload)
+
+    for _ in range(100):
+        if delivery.stats()["queued"] == 0:
+            break
+        time.sleep(0.02)
+    delivery.stop()
+
+    assert sent and sent[0]["tracked"][0] == payload
+    stats = delivery.stats()
+    assert stats["queued"] == 0
+    assert stats["total_sent"] == 1
+    assert stats["total_failed"] == 0


### PR DESCRIPTION
## Summary
- document PersistentDelivery with `stats()` and remove stale `deliver_now` example
- add unit tests covering MemQueueDelivery and PersistentDelivery success metrics

## Testing
- `pytest tests/test_mem_queue_delivery.py tests/test_persistent_delivery.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_68a332c24408832bb9e16acb05e8c42e