### PR TITLE
Add triggered limit updates to delivery

### DIFF
--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from ..client import CostManagerClient
+from ..limits import TriggeredLimitManager
 from .base import Delivery, DeliveryConfig, DeliveryType
 
 
@@ -17,6 +19,20 @@ class ImmediateDelivery(Delivery):
         body = {self._body_key: [payload]}
         try:
             self._post_with_retry(body, max_attempts=3)
+            client: CostManagerClient | None = None
+            try:
+                client = CostManagerClient(
+                    aicm_api_key=self.api_key,
+                    aicm_api_base=self.api_base,
+                    aicm_api_url=self.api_url,
+                    aicm_ini_path=self.ini_manager.ini_path,
+                )
+                TriggeredLimitManager(client).update_triggered_limits()
+            except Exception as exc:
+                self.logger.error("Triggered limits update failed: %s", exc)
+            finally:
+                if client is not None:
+                    client.close()
         except Exception as exc:
             self.logger.exception("Immediate delivery failed: %s", exc)
             raise


### PR DESCRIPTION
## Summary
- add async update_triggered_limits to TriggeredLimitManager
- update immediate delivery to persist triggered limits after tracking
- ensure queued deliveries refresh triggered limits asynchronously

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3393d37dc832b8c3ba01291979e8e