### PR TITLE
Add LLM usage tracking helpers to Tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- `track_llm_usage` and `track_llm_usage_async` methods for automatic usage
+  extraction from LLM responses, with streaming helpers.
+
 ## [0.1.18] - 2025-08-11
 ### Added
 

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -89,6 +89,29 @@ async def track(payload: dict) -> dict:
     return {"status": "queued"}
 ```
 
+## LLM response helpers
+
+The tracker can derive usage directly from LLM client responses:
+
+```python
+resp = client.chat.completions.create(...)
+tracker.track_llm_usage("openai_chat", "gpt-5-mini", resp)
+```
+
+For streaming responses, wrap the iterator to capture usage once it becomes
+available:
+
+```python
+stream = client.chat.completions.create(
+    ..., stream=True, stream_options={"include_usage": True}
+)
+for event in tracker.track_llm_stream_usage("openai_chat", "gpt-5-mini", stream):
+    handle(event)
+```
+
+Asynchronous variants ``track_llm_usage_async`` and
+``track_llm_stream_usage_async`` mirror the synchronous versions.
+
 ## Shutting down
 
 `Tracker` owns a background worker responsible for delivering queued

--- a/tests/test_tracker_llm_usage.py
+++ b/tests/test_tracker_llm_usage.py
@@ -1,0 +1,98 @@
+import json
+import asyncio
+
+from aicostmanager.tracker import Tracker
+from aicostmanager.ini_manager import IniManager
+
+
+class Resp:
+    def __init__(self, usage):
+        self.usage = usage
+
+
+class DummyDelivery:
+    def __init__(self):
+        self.records = []
+        self.type = None
+
+    def enqueue(self, record):
+        self.records.append(record)
+
+    def stop(self):
+        pass
+
+
+def test_track_llm_usage():
+    delivery = DummyDelivery()
+    tracker = Tracker(delivery=delivery, ini_manager=IniManager("ini"))
+
+    resp = Resp({"input_tokens": 1})
+    out = tracker.track_llm_usage("openai_chat", "gpt-5-mini", resp, client_customer_key="abc")
+    assert out is resp
+    tracker.close()
+
+    record = delivery.records[0]
+    assert record["payload"] == {"input_tokens": 1}
+    assert record["api_id"] == "openai_chat"
+    assert record["service_key"] == "gpt-5-mini"
+    assert record["client_customer_key"] == "abc"
+
+
+def test_track_llm_usage_async():
+    delivery = DummyDelivery()
+    tracker = Tracker(delivery=delivery, ini_manager=IniManager("ini"))
+
+    class AResp:
+        usage = {"input_tokens": 2}
+
+    async def run():
+        resp = AResp()
+        out = await tracker.track_llm_usage_async("openai_chat", "gpt-4", resp)
+        assert out is resp
+
+    asyncio.run(run())
+    tracker.close()
+
+    record = delivery.records[0]
+    assert record["payload"] == {"input_tokens": 2}
+
+
+def test_track_llm_stream_usage():
+    delivery = DummyDelivery()
+    tracker = Tracker(delivery=delivery, ini_manager=IniManager("ini"))
+
+    class Chunk:
+        def __init__(self, usage=None):
+            self.usage = usage
+
+    chunks = [Chunk(), Chunk({"input_tokens": 3})]
+    events = list(tracker.track_llm_stream_usage("openai_chat", "gpt-5-mini", chunks))
+    assert events == chunks
+    tracker.close()
+
+    record = delivery.records[0]
+    assert record["payload"] == {"input_tokens": 3}
+
+
+def test_track_llm_stream_usage_async():
+    delivery = DummyDelivery()
+    tracker = Tracker(delivery=delivery, ini_manager=IniManager("ini"))
+
+    class Chunk:
+        def __init__(self, usage=None):
+            self.usage = usage
+
+    async def stream():
+        for c in [Chunk(), Chunk({"input_tokens": 4})]:
+            yield c
+
+    async def run():
+        async for _ in tracker.track_llm_stream_usage_async("openai_chat", "gpt-5-mini", stream()):
+            pass
+
+    asyncio.run(run())
+    tracker.close()
+
+    record = delivery.records[0]
+    assert record["payload"] == {"input_tokens": 4}
+


### PR DESCRIPTION
## Summary
- add `track_llm_usage`/`track_llm_usage_async` for automatic extraction from LLM responses
- support streaming with `track_llm_stream_usage` and async variant
- document LLM response helpers and record in changelog

## Testing
- `pytest tests/test_tracker_llm_usage.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68a365bd35e0832b9aa89f84749e7527