### PR TITLE
Add base README and document API key requirement

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # AICostManager Documentation
 
+To use the SDK you must create a free account at [AICostManager](https://aicostmanager.com)
+and generate an API key. Set it in the `AICM_API_KEY` environment variable or
+pass it directly to the client or tracker.
+
 ## User Guides
 
 - [Usage](usage.md) - Basic SDK usage and API examples

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -4,6 +4,10 @@ The `Tracker` provides a lightweight way to send arbitrary usage payloads to
 AICostManager's `/track` endpoint.  It does not require configuration metadata
 and forwards any JSON-serialisable data that you supply.
 
+Before using the tracker, create a free account at
+[AICostManager](https://aicostmanager.com) and set your API key in the
+`AICM_API_KEY` environment variable or pass it to the constructor.
+
 ## Creating a tracker
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,9 @@
 # Using the Python SDK
 
+Before you begin, sign up for a free account at [AICostManager](https://aicostmanager.com)
+and obtain an API key. Export it as `AICM_API_KEY` or pass it directly to
+`CostManagerClient` or `Tracker`.
+
 Install with:
 
 ```bash


### PR DESCRIPTION
## Summary
- create top-level README with install steps, delivery guidance and usage examples
- highlight need for a free account and API key in docs

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3cc3637b8832ba8e859665c8a29d9