### PR TITLE
Centralize tracker configuration with TrackerConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ with Tracker() as tracker:
 Using `with Tracker()` ensures the background delivery queue is flushed before
 the program exits.
 
+Configuration values are loaded from ``AICM.INI`` and environment variables.
+To manage these settings explicitly, construct a ``TrackerConfig``:
+
+```python
+from aicostmanager import Tracker, TrackerConfig
+
+config = TrackerConfig.from_env()
+tracker = Tracker(config)
+```
+
 ## Choosing a delivery strategy
 
 `Tracker` supports multiple delivery components via `DeliveryType`:

--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -22,6 +22,7 @@ from .delivery import (
 )
 from .limits import BaseLimitManager, TriggeredLimitManager, UsageLimitManager
 from .tracker import Tracker
+from .tracker_config import TrackerConfig
 
 __all__ = [
     "AICMError",
@@ -39,6 +40,7 @@ __all__ = [
     "MemQueueDelivery",
     "PersistentDelivery",
     "Tracker",
+    "TrackerConfig",
     "BaseLimitManager",
     "TriggeredLimitManager",
     "UsageLimitManager",

--- a/aicostmanager/tracker_config.py
+++ b/aicostmanager/tracker_config.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, fields
+from typing import Any
+
+import httpx
+
+from .ini_manager import IniManager
+from .delivery import DeliveryType
+
+
+def _to_bool(val: str) -> bool:
+    return val.lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class TrackerConfig:
+    """Configuration container for :class:`~aicostmanager.tracker.Tracker`."""
+
+    ini_manager: IniManager
+    delivery_type: DeliveryType | None = None
+    aicm_api_key: str | None = None
+    aicm_api_base: str | None = None
+    aicm_api_url: str | None = None
+    db_path: str | None = None
+    log_file: str | None = None
+    log_level: str | None = None
+    timeout: float = 10.0
+    poll_interval: float = 0.1
+    batch_interval: float = 0.5
+    max_attempts: int = 3
+    max_retries: int = 5
+    queue_size: int = 10000
+    max_batch_size: int = 1000
+    transport: httpx.BaseTransport | None = None
+    log_bodies: bool = False
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        ini_manager: IniManager | None = None,
+        aicm_ini_path: str | None = None,
+        **overrides: Any,
+    ) -> "TrackerConfig":
+        """Load configuration from an INI file and environment variables.
+
+        ``AICM_API_KEY`` is read from the environment (or ``overrides``) while the
+        remaining options are loaded from ``[tracker]`` in the INI file.  Keyword
+        arguments override values loaded from the INI file.
+        """
+        if ini_manager is None:
+            ini_manager = IniManager(IniManager.resolve_path(aicm_ini_path))
+
+        cfg = cls(ini_manager=ini_manager)
+        parse_map: dict[str, Any] = {
+            "timeout": float,
+            "poll_interval": float,
+            "batch_interval": float,
+            "max_attempts": int,
+            "max_retries": int,
+            "queue_size": int,
+            "max_batch_size": int,
+            "log_bodies": _to_bool,
+            "delivery_type": DeliveryType,
+        }
+
+        for f in fields(cls):
+            if f.name == "ini_manager":
+                continue
+            if f.name == "aicm_api_key":
+                val = overrides.get(f.name) or os.getenv("AICM_API_KEY")
+                setattr(cfg, f.name, val)
+                continue
+            if f.name in overrides:
+                setattr(cfg, f.name, overrides[f.name])
+                continue
+            ini_val = ini_manager.get_option("tracker", f.name, None)
+            if ini_val is not None:
+                parser = parse_map.get(f.name)
+                if parser is not None:
+                    ini_val = parser(ini_val)
+                setattr(cfg, f.name, ini_val)
+        return cfg

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -17,6 +17,16 @@ with Tracker() as tracker:
     ...  # call track() as needed
 ```
 
+For explicit control over configuration, build a ``TrackerConfig`` from the
+environment and INI file:
+
+```python
+from aicostmanager import Tracker, TrackerConfig
+
+config = TrackerConfig.from_env()
+tracker = Tracker(config)
+```
+
 ## Choosing a delivery manager
 
 The tracker supports multiple delivery strategies selected via `DeliveryType`. The default `immediate` mode sends each record synchronously with up to three retries for transient errors. Use `mem_queue` for an in-memory background queue or `persistent_queue` for a durable SQLite-backed queue:
@@ -27,7 +37,7 @@ from aicostmanager import Tracker, DeliveryType
 tracker = Tracker(delivery_type=DeliveryType.MEM_QUEUE)
 ```
 
-The constructor accepts the same connection options as
+``TrackerConfig.from_env`` accepts the same connection options as
 `PersistentDelivery`, such as `aicm_api_key`, `aicm_api_base` and
 `aicm_ini_path`.  The delivery system writes logs to the Python logging
 module.  To inspect activity, pass `log_file` and a verbose

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -3,7 +3,7 @@ import json
 
 import httpx
 
-from aicostmanager import Tracker
+from aicostmanager import Tracker, TrackerConfig
 from aicostmanager.ini_manager import IniManager
 
 
@@ -15,7 +15,10 @@ def test_tracker_builds_record():
         return httpx.Response(200, json={"ok": True})
 
     transport = httpx.MockTransport(handler)
-    tracker = Tracker(aicm_api_key="test", transport=transport, ini_manager=IniManager("ini"))
+    cfg = TrackerConfig.from_env(
+        aicm_api_key="test", transport=transport, ini_manager=IniManager("ini")
+    )
+    tracker = Tracker(cfg)
     tracker.track("openai", "gpt-5-mini", {"input_tokens": 1}, client_customer_key="abc")
     tracker.close()
     assert received
@@ -33,7 +36,10 @@ def test_tracker_track_async():
         return httpx.Response(200, json={"ok": True})
 
     transport = httpx.MockTransport(handler)
-    tracker = Tracker(aicm_api_key="test", transport=transport, ini_manager=IniManager("ini"))
+    cfg = TrackerConfig.from_env(
+        aicm_api_key="test", transport=transport, ini_manager=IniManager("ini")
+    )
+    tracker = Tracker(cfg)
 
     async def run():
         await tracker.track_async("openai", "gpt-5-mini", {"input_tokens": 1})


### PR DESCRIPTION
## Summary
- add `TrackerConfig` dataclass to load tracker settings from INI and environment variables
- refactor `Tracker` to accept `TrackerConfig` or legacy kwargs
- document new configuration pattern and update tests

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3cabb1ce4832ba111ea369604ebde