### PR TITLE
Enforce triggered limit checks after delivery

### DIFF
--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from ..client import CostManagerClient
-from ..limits import TriggeredLimitManager
 from .base import Delivery, DeliveryConfig, DeliveryType
 
 
@@ -15,24 +13,11 @@ class ImmediateDelivery(Delivery):
     def __init__(self, config: DeliveryConfig) -> None:
         super().__init__(config)
 
-    def enqueue(self, payload: Dict[str, Any]) -> None:
+    def _enqueue(self, payload: Dict[str, Any]) -> None:
         body = {self._body_key: [payload]}
         try:
             self._post_with_retry(body, max_attempts=3)
-            client: CostManagerClient | None = None
-            try:
-                client = CostManagerClient(
-                    aicm_api_key=self.api_key,
-                    aicm_api_base=self.api_base,
-                    aicm_api_url=self.api_url,
-                    aicm_ini_path=self.ini_manager.ini_path,
-                )
-                TriggeredLimitManager(client).update_triggered_limits()
-            except Exception as exc:
-                self.logger.error("Triggered limits update failed: %s", exc)
-            finally:
-                if client is not None:
-                    client.close()
+            self._refresh_triggered_limits()
         except Exception as exc:
             self.logger.exception("Immediate delivery failed: %s", exc)
             raise

--- a/aicostmanager/delivery/mem_queue.py
+++ b/aicostmanager/delivery/mem_queue.py
@@ -24,7 +24,7 @@ class MemQueueDelivery(QueueDelivery):
         max_attempts = kwargs.pop("max_attempts", kwargs.pop("max_retries", 5))
         super().__init__(config, max_attempts=max_attempts, max_retries=0, **kwargs)
 
-    def enqueue(self, payload: Dict[str, Any]) -> None:
+    def _enqueue(self, payload: Dict[str, Any]) -> None:
         try:
             self._queue.put_nowait(payload)
         except queue.Full:

--- a/aicostmanager/delivery/persistent.py
+++ b/aicostmanager/delivery/persistent.py
@@ -66,7 +66,7 @@ class PersistentDelivery(QueueDelivery):
             logger=logger,
         )
 
-    def enqueue(self, payload: Dict[str, Any]) -> int:
+    def _enqueue(self, payload: Dict[str, Any]) -> int:
         now = time.time()
         data = json.dumps(payload)
         with self._lock:

--- a/docs/limit_managers.md
+++ b/docs/limit_managers.md
@@ -75,3 +75,7 @@ events = tl_mgr.check_triggered_limits(
 for tl in events:
     print(tl.limit_id, tl.threshold_type)
 ```
+
+Delivery components use the same cached data to enforce limits automatically.
+After a payload is sent or enqueued, the tracker checks these events and raises
+``UsageLimitExceeded`` when a matching limit has already been triggered.

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -74,6 +74,15 @@ tracker.track(
 )
 ```
 
+### Triggered limit enforcement
+
+Every delivery mechanism refreshes triggered limit data from the API after
+successfully sending a batch. Once a payload is enqueued, the tracker compares
+it against the cached limits and raises
+:class:`~aicostmanager.client.exceptions.UsageLimitExceeded` if the payload
+matches a triggered limit. The check occurs *after* the enqueue or delivery
+action so tracking data is never discarded even when a limit has been reached.
+
 ## Asynchronous usage
 
 All operations are safe to call from asynchronous applications.  The

--- a/tests/test_delivery_triggered_limits.py
+++ b/tests/test_delivery_triggered_limits.py
@@ -1,0 +1,88 @@
+import pathlib
+import time
+from types import SimpleNamespace
+
+import jwt
+import pytest
+
+from aicostmanager.delivery import DeliveryConfig
+from aicostmanager.delivery.immediate import ImmediateDelivery
+from aicostmanager.delivery.mem_queue import MemQueueDelivery
+from aicostmanager.ini_manager import IniManager
+from aicostmanager.config_manager import CostManagerConfig
+from aicostmanager.client.exceptions import UsageLimitExceeded
+
+PRIVATE_KEY = (pathlib.Path(__file__).parent / "threshold_private_key.pem").read_text()
+PUBLIC_KEY = (pathlib.Path(__file__).parent / "threshold_public_key.pem").read_text()
+
+
+def _setup_triggered_limits(ini_path):
+    now = int(time.time())
+    event = {
+        "event_id": "evt-api-key-limit",
+        "limit_id": "lmt-api-key-limit",
+        "threshold_type": "limit",
+        "amount": 100.0,
+        "period": "month",
+        "limit_context": "key",
+        "limit_message": "Usage limit exceeded",
+        "service_key": "openai::gpt-4",
+        "client_customer_key": "api-key-customer",
+        "api_key_id": "550e8400-e29b-41d4-a716-446655440000",
+        "triggered_at": "2024-12-31T18:00:00Z",
+        "expires_at": "2025-01-01T18:00:00Z",
+    }
+    payload = {
+        "iss": "aicm-api",
+        "sub": event["api_key_id"],
+        "iat": now,
+        "jti": "tl",
+        "version": "v1",
+        "key_id": "test",
+        "triggered_limits": [event],
+    }
+    token = jwt.encode(payload, PRIVATE_KEY, algorithm="RS256", headers={"kid": "test"})
+    item = {"version": "v1", "public_key": PUBLIC_KEY, "key_id": "test", "encrypted_payload": token}
+    cfg = CostManagerConfig(SimpleNamespace(ini_path=str(ini_path), get_triggered_limits=lambda: {}))
+    cfg.write_triggered_limits(item)
+    return event
+
+
+def test_mem_queue_enforce_triggered_limit(tmp_path):
+    ini = tmp_path / "AICM.ini"
+    event = _setup_triggered_limits(ini)
+    config = DeliveryConfig(ini_manager=IniManager(str(ini)), aicm_api_key=event["api_key_id"])
+    delivery = MemQueueDelivery(config)
+    payload = {
+        "api_id": "openai",
+        "service_key": event["service_key"],
+        "client_customer_key": event["client_customer_key"],
+        "payload": {},
+    }
+    with pytest.raises(UsageLimitExceeded):
+        delivery.enqueue(payload)
+    assert delivery.queued() == 1
+
+
+def test_immediate_enforce_triggered_limit(tmp_path):
+    ini = tmp_path / "AICM.ini"
+    event = _setup_triggered_limits(ini)
+    config = DeliveryConfig(ini_manager=IniManager(str(ini)), aicm_api_key=event["api_key_id"])
+    delivery = ImmediateDelivery(config)
+    called = {}
+
+    def fake_post(body, max_attempts):
+        called["called"] = True
+
+    delivery._post_with_retry = fake_post
+    delivery._refresh_triggered_limits = lambda: None
+
+    payload = {
+        "api_id": "openai",
+        "service_key": event["service_key"],
+        "client_customer_key": event["client_customer_key"],
+        "payload": {},
+    }
+    with pytest.raises(UsageLimitExceeded):
+        delivery.enqueue(payload)
+    assert called.get("called")


### PR DESCRIPTION
## Summary
- check payloads against cached triggered limits after every enqueue and raise `UsageLimitExceeded`
- refresh triggered limit cache via lightweight HTTP calls instead of spinning up full clients
- document and test triggered limit enforcement

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic==2.7.1 httpx==0.27.0` *(fails: Could not find a version that satisfies the requirement pydantic==2.7.1)*

------
https://chatgpt.com/codex/tasks/task_b_68a3d73dd5c0832b8ae3eb6270608ff0