### PR TITLE
Refactor configuration manager API

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -10,7 +10,7 @@ from .client import (
     MissingConfiguration,
     UsageLimitExceeded,
 )
-from .config_manager import CostManagerConfig
+from .config_manager import ConfigManager
 from .delivery import (
     Delivery,
     DeliveryConfig,
@@ -31,7 +31,7 @@ __all__ = [
     "CostManagerClient",
     "MissingConfiguration",
     "UsageLimitExceeded",
-    "CostManagerConfig",
+    "ConfigManager",
     "Delivery",
     "DeliveryType",
     "create_delivery",

--- a/aicostmanager/client/base.py
+++ b/aicostmanager/client/base.py
@@ -40,9 +40,9 @@ class BaseClient:
 
     def _store_triggered_limits(self, triggered_limits_response) -> None:
         """Persist triggered limits using the configuration manager."""
-        from ..config_manager import CostManagerConfig
+        from ..config_manager import ConfigManager
 
-        cfg_mgr = CostManagerConfig(self)
+        cfg_mgr = ConfigManager(ini_path=self.ini_path)
         if isinstance(triggered_limits_response, dict):
             tl_data = triggered_limits_response.get(
                 "triggered_limits", triggered_limits_response

--- a/aicostmanager/delivery/base.py
+++ b/aicostmanager/delivery/base.py
@@ -6,7 +6,6 @@ import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -18,7 +17,7 @@ from tenacity import (
 )
 
 from ..client.exceptions import UsageLimitExceeded
-from ..config_manager import CostManagerConfig
+from ..config_manager import ConfigManager
 from ..ini_manager import IniManager
 from ..logger import create_logger
 
@@ -112,22 +111,12 @@ class Delivery(ABC):
             tl_data = data.get("triggered_limits", data)
         else:
             tl_data = data
-        cfg = CostManagerConfig(
-            SimpleNamespace(
-                ini_path=self.ini_manager.ini_path,
-                get_triggered_limits=lambda: {},
-            )
-        )
+        cfg = ConfigManager(ini_path=self.ini_manager.ini_path)
         cfg.write_triggered_limits(tl_data)
 
     def _check_triggered_limits(self, payload: Dict[str, Any]) -> None:
         """Raise ``UsageLimitExceeded`` if ``payload`` matches a triggered limit."""
-        cfg = CostManagerConfig(
-            SimpleNamespace(
-                ini_path=self.ini_manager.ini_path,
-                get_triggered_limits=lambda: {},
-            )
-        )
+        cfg = ConfigManager(ini_path=self.ini_manager.ini_path)
         tl_raw = cfg.read_triggered_limits()
         if "encrypted_payload" not in tl_raw or "public_key" not in tl_raw:
             return

--- a/aicostmanager/limits/triggered.py
+++ b/aicostmanager/limits/triggered.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from ..client import AsyncCostManagerClient, CostManagerClient
-from ..config_manager import CostManagerConfig, TriggeredLimit
+from ..config_manager import ConfigManager, TriggeredLimit
 from .base import BaseLimitManager
 
 
@@ -13,10 +13,10 @@ class TriggeredLimitManager(BaseLimitManager):
     def __init__(
         self,
         client: CostManagerClient | AsyncCostManagerClient,
-        config_manager: CostManagerConfig | None = None,
+        config_manager: ConfigManager | None = None,
     ) -> None:
         super().__init__(client)
-        self.config_manager = config_manager or CostManagerConfig(client)
+        self.config_manager = config_manager or ConfigManager(client)
 
     def update_triggered_limits(self) -> None:
         data = self.client.get_triggered_limits() or {}

--- a/tests/test_delivery_triggered_limits.py
+++ b/tests/test_delivery_triggered_limits.py
@@ -1,6 +1,5 @@
 import pathlib
 import time
-from types import SimpleNamespace
 
 import jwt
 import pytest
@@ -9,7 +8,7 @@ from aicostmanager.delivery import DeliveryConfig
 from aicostmanager.delivery.immediate import ImmediateDelivery
 from aicostmanager.delivery.mem_queue import MemQueueDelivery
 from aicostmanager.ini_manager import IniManager
-from aicostmanager.config_manager import CostManagerConfig
+from aicostmanager.config_manager import ConfigManager
 from aicostmanager.client.exceptions import UsageLimitExceeded
 
 PRIVATE_KEY = (pathlib.Path(__file__).parent / "threshold_private_key.pem").read_text()
@@ -43,7 +42,7 @@ def _setup_triggered_limits(ini_path):
     }
     token = jwt.encode(payload, PRIVATE_KEY, algorithm="RS256", headers={"kid": "test"})
     item = {"version": "v1", "public_key": PUBLIC_KEY, "key_id": "test", "encrypted_payload": token}
-    cfg = CostManagerConfig(SimpleNamespace(ini_path=str(ini_path), get_triggered_limits=lambda: {}))
+    cfg = ConfigManager(ini_path=str(ini_path))
     cfg.write_triggered_limits(item)
     return event
 

--- a/tests/test_limits_manager.py
+++ b/tests/test_limits_manager.py
@@ -3,7 +3,7 @@ import time
 import jwt
 
 from aicostmanager.client import CostManagerClient
-from aicostmanager.config_manager import CostManagerConfig
+from aicostmanager.config_manager import ConfigManager
 from aicostmanager.limits import TriggeredLimitManager, UsageLimitManager
 from aicostmanager.models import (
     UsageLimitIn,
@@ -50,7 +50,7 @@ def _make_triggered_limits():
 def test_update_and_check(monkeypatch, tmp_path):
     ini = tmp_path / "AICM.ini"
     client = CostManagerClient(aicm_api_key="sk-test", aicm_ini_path=str(ini))
-    cfg_mgr = CostManagerConfig(client)
+    cfg_mgr = ConfigManager(client)
     tl_mgr = TriggeredLimitManager(client, cfg_mgr)
 
     item, event = _make_triggered_limits()


### PR DESCRIPTION
## Summary
- rename `CostManagerConfig` to `ConfigManager`
- allow initialization via client or ini path
- simplify delivery triggered-limit checks to instantiate `ConfigManager` directly
- remove unused `CostManagerConfig` alias and export only `ConfigManager`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic'; ModuleNotFoundError: No module named 'httpx'; ModuleNotFoundError: No module named 'jwt')*
- `pip install pydantic httpx PyJWT` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_b_68a3de3bb8d4832b8d1bd9b8fd6bf4d7