### PR TITLE
Cache triggered limits in memory

### DIFF
--- a/aicostmanager/delivery/base.py
+++ b/aicostmanager/delivery/base.py
@@ -110,10 +110,7 @@ class Delivery(ABC):
 
     def _check_triggered_limits(self, payload: Dict[str, Any]) -> None:
         """Raise ``UsageLimitExceeded`` if ``payload`` matches a triggered limit."""
-        cfg = ConfigManager(ini_path=self.ini_manager.ini_path)
-        tl_raw = cfg.read_triggered_limits()
-        if "encrypted_payload" not in tl_raw or "public_key" not in tl_raw:
-            return
+        cfg = ConfigManager(ini_path=self.ini_manager.ini_path, load=False)
         service_key = payload.get("service_key")
         vendor = service_id = None
         if service_key and "::" in service_key:

--- a/aicostmanager/triggered_limits_cache.py
+++ b/aicostmanager/triggered_limits_cache.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from threading import RLock
+from typing import Any, List, Optional
+
+
+class TriggeredLimitsCache:
+    """Thread-safe in-memory cache for decrypted triggered limits."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._data: Optional[List[dict]] = None
+
+    def get(self) -> Optional[List[dict]]:
+        with self._lock:
+            return self._data
+
+    def set(self, value: List[dict]) -> None:
+        with self._lock:
+            self._data = value
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data = None
+
+
+triggered_limits_cache = TriggeredLimitsCache()

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -59,11 +59,13 @@ tracker.track(
 ### Triggered limit enforcement
 
 Every delivery mechanism refreshes triggered limit data from the API after
-successfully sending a batch. Once a payload is enqueued, the tracker compares
-it against the cached limits and raises
-:class:`~aicostmanager.client.exceptions.UsageLimitExceeded` if the payload
-matches a triggered limit. The check occurs *after* the enqueue or delivery
-action so tracking data is never discarded even when a limit has been reached.
+successfully sending a batch. The decrypted limits are cached in memory and
+persisted to ``AICM.ini`` as a fallback. Enqueued payloads are compared against
+this in-memory cache and
+:class:`~aicostmanager.client.exceptions.UsageLimitExceeded` is raised if the
+payload matches a triggered limit. The check occurs *after* the enqueue or
+delivery action so tracking data is never discarded even when a limit has been
+reached.
 
 ## Asynchronous usage
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import os
 
 import pytest
+from aicostmanager.triggered_limits_cache import triggered_limits_cache
 try:
     from dotenv import load_dotenv
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
@@ -152,3 +153,10 @@ def cleanup_ini_files():
             os.remove(ini_file)
         except OSError:
             pass
+
+
+@pytest.fixture(autouse=True)
+def reset_triggered_limits_cache():
+    triggered_limits_cache.clear()
+    yield
+    triggered_limits_cache.clear()


### PR DESCRIPTION
## Summary
- Cache decrypted triggered limits in-memory with thread-safe access
- Use cache for delivery limit checks to avoid repeated INI reads and decryption
- Document new in-memory triggered limit cache

## Testing
- `pytest tests/test_delivery_triggered_limits.py::test_triggered_limits_cached_in_memory -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68a442f9b330832b843a75e92af510b5