### PR TITLE
Add framework integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ def my_view(request):
     tracker.track("openai", "gpt-4o-mini", {"input_tokens": 10})
     ...
 ```
+For a full setup guide, see [Django integration guide](docs/django.md).
 
 ### FastAPI
 
@@ -110,6 +111,27 @@ async def startup() -> None:
 def shutdown() -> None:
     app.state.tracker.close()
 ```
+For a full setup guide, see [FastAPI integration guide](docs/fastapi.md).
+
+### Streamlit
+
+```python
+import streamlit as st
+from aicostmanager import Tracker
+import atexit
+
+@st.cache_resource
+def get_tracker():
+    tracker = Tracker()
+    atexit.register(tracker.close)
+    return tracker
+
+tracker = get_tracker()
+
+if st.button("Generate"):
+    tracker.track("openai", "gpt-4o-mini", {"input_tokens": 10})
+```
+For a full setup guide, see [Streamlit integration guide](docs/streamlit.md).
 
 ### Celery
 
@@ -139,5 +161,8 @@ to ensure flushing.
 - [Tracker](docs/tracker.md)
 - [Configuration](docs/config.md)
 - [Persistent Delivery](docs/persistent_delivery.md)
+- [Django integration](docs/django.md)
+- [FastAPI integration](docs/fastapi.md)
+- [Streamlit integration](docs/streamlit.md)
 - [Full documentation index](docs/index.md)
 

--- a/docs/django.md
+++ b/docs/django.md
@@ -1,0 +1,83 @@
+# Django Integration
+
+This guide shows how to add cost tracking to a Django project using the
+AICostManager SDK.
+
+## Install the SDK
+
+```bash
+uv pip install aicostmanager
+# or
+pip install aicostmanager
+```
+
+## Configuration file
+
+1. Create an `AICM.INI` file in your project root:
+
+```ini
+[aicostmanager]
+AICM_API_KEY = sk-api01-...
+# Optional overrides
+AICM_DELIVERY_TYPE = MEM_QUEUE
+AICM_LOG_FILE = aicm.log
+```
+
+2. Register the file path in `settings.py` so other components can reference
+   it:
+
+```python
+# settings.py
+from pathlib import Path
+BASE_DIR = Path(__file__).resolve().parent.parent
+AICM_INI_PATH = BASE_DIR / "AICM.INI"
+```
+
+The tracker will automatically load configuration from this file when the path
+is supplied.
+
+## Initialising the tracker
+
+Create a tracker when Django starts and close it when the process exits. An
+app configuration is a convenient place:
+
+```python
+# myapp/apps.py
+from django.apps import AppConfig
+from django.conf import settings
+from aicostmanager import Tracker
+import atexit
+
+class MyAppConfig(AppConfig):
+    name = "myapp"
+
+    def ready(self):
+        self.tracker = Tracker(ini_path=getattr(settings, "AICM_INI_PATH", None))
+        atexit.register(self.tracker.close)
+```
+
+Access the tracker from views:
+
+```python
+# myapp/views.py
+from django.apps import apps
+
+
+def my_view(request):
+    tracker = apps.get_app_config("myapp").tracker
+    tracker.track("openai", "gpt-4o-mini", {"input_tokens": 10})
+    ...
+```
+
+## Asynchronous views
+
+For async views, call `track_async` to run tracking in a worker thread:
+
+```python
+async def my_async_view(request):
+    tracker = apps.get_app_config("myapp").tracker
+    await tracker.track_async("openai", "gpt-4o-mini", {"input_tokens": 10})
+```
+
+With these pieces in place, the tracker will flush queued usage when Django
+shuts down, ensuring reliable cost reporting.

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -1,0 +1,77 @@
+# FastAPI Integration
+
+This guide covers setting up the AICostManager tracker in a FastAPI
+application.
+
+## Install the SDK
+
+```bash
+uv pip install aicostmanager
+# or
+pip install aicostmanager
+```
+
+## Configuration file
+
+Create an `AICM.INI` file in your project directory:
+
+```ini
+[aicostmanager]
+AICM_API_KEY = sk-api01-...
+# Optional overrides
+AICM_DELIVERY_TYPE = PERSISTENT_QUEUE
+AICM_DB_PATH = ./aicm.db
+```
+
+Expose the path through an environment variable or settings class:
+
+```bash
+export AICM_INI_PATH=/path/to/AICM.INI
+```
+
+## Application startup and shutdown
+
+Initialise the tracker during startup so configuration loading does not block
+individual requests. Use `Tracker.create_async` to perform setup in a worker
+thread and close the tracker on shutdown:
+
+```python
+from fastapi import FastAPI
+from aicostmanager import Tracker
+import os
+
+app = FastAPI()
+
+@app.on_event("startup")
+async def startup() -> None:
+    ini_path = os.getenv("AICM_INI_PATH")
+    app.state.tracker = await Tracker.create_async(ini_path=ini_path)
+
+@app.on_event("shutdown")
+def shutdown() -> None:
+    app.state.tracker.close()
+```
+
+## Recording usage
+
+Inside route handlers, use the tracker to send usage data:
+
+```python
+from fastapi import Request
+
+@app.post("/track")
+async def track_usage(request: Request) -> dict:
+    payload = await request.json()
+    app.state.tracker.track("openai", "gpt-4o-mini", payload)
+    return {"status": "queued"}
+```
+
+If the payload construction is CPU heavy, `track_async` will offload it to a
+worker thread:
+
+```python
+await app.state.tracker.track_async("openai", "gpt-4o-mini", payload)
+```
+
+With the tracker created at startup and closed on shutdown, FastAPI services
+can report usage without blocking request handling.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ pass it directly to the client or tracker.
 - [Manual Usage Tracking](tracker.md) - Record custom usage events
 - [Configuration](config.md) - Settings and defaults
 - [Limit Managers](limit_managers.md) - Manage usage limits and triggered limits
+- [Django](django.md) - Integrate with Django projects
+- [FastAPI](fastapi.md) - Integrate with FastAPI applications
+- [Streamlit](streamlit.md) - Track usage from Streamlit apps
 
 ## Development
 

--- a/docs/streamlit.md
+++ b/docs/streamlit.md
@@ -1,0 +1,65 @@
+# Streamlit Integration
+
+This guide explains how to track usage from a Streamlit application.
+
+## Install the SDK
+
+```bash
+uv pip install aicostmanager
+# or
+pip install aicostmanager
+```
+
+## Configuration file
+
+Create an `AICM.INI` file next to your Streamlit script:
+
+```ini
+[aicostmanager]
+AICM_API_KEY = sk-api01-...
+# Optional overrides
+AICM_DELIVERY_TYPE = MEM_QUEUE
+```
+
+Store the path in `.streamlit/secrets.toml` so it is available at runtime:
+
+```toml
+# .streamlit/secrets.toml
+AICM_INI_PATH = "./AICM.INI"
+```
+
+## Creating a cached tracker
+
+Use `st.cache_resource` to construct the tracker once per process and close it
+on exit:
+
+```python
+import streamlit as st
+from aicostmanager import Tracker
+import atexit
+
+@st.cache_resource
+def get_tracker() -> Tracker:
+    tracker = Tracker(ini_path=st.secrets.get("AICM_INI_PATH"))
+    atexit.register(tracker.close)
+    return tracker
+
+tracker = get_tracker()
+```
+
+## Recording usage
+
+Call the tracker when handling user actions:
+
+```python
+def main():
+    if st.button("Generate"):
+        tracker.track("openai", "gpt-4o-mini", {"input_tokens": 10})
+        st.write("queued")
+
+if __name__ == "__main__":
+    main()
+```
+
+For short-lived scripts you can also use `with Tracker() as t:` to automatically
+flush the queue.


### PR DESCRIPTION
## Summary
- Document Django setup with example `AICM.INI` config and tracker initialization
- Add FastAPI guide covering configuration, startup hooks and usage tracking
- Introduce Streamlit integration guide with cached tracker example
- Link new framework guides from README and docs index

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_b_68a448d9b054832b8661ac1118e2a415