### PR TITLE
feat: add config toggle for triggered limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `track_llm_usage` and `track_llm_usage_async` methods for automatic usage
   extraction from LLM responses, with streaming helpers.
+- `AICM_LIMITS_ENABLED` configuration to toggle triggered limit enforcement in
+  delivery components.
 
 ## [0.1.18] - 2025-08-11
 ### Added

--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -19,10 +19,11 @@ class ImmediateDelivery(Delivery):
             # Base class enqueue already refreshed and checked limits pre-send
             self._post_with_retry(body, max_attempts=3)
             # Refresh after successful send so subsequent calls see updated state
-            try:
-                self._refresh_triggered_limits()
-            except Exception as exc:  # pragma: no cover - network failures
-                self.logger.error("Triggered limits update failed: %s", exc)
+            if self._limits_enabled():
+                try:
+                    self._refresh_triggered_limits()
+                except Exception as exc:  # pragma: no cover - network failures
+                    self.logger.error("Triggered limits update failed: %s", exc)
         except Exception as exc:
             self.logger.exception("Immediate delivery failed: %s", exc)
             raise

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,7 @@ All configuration keys are fully capitalised and prefixed with `AICM_`.
 | `AICM_LOG_FILE` | – | Path to a log file |
 | `AICM_LOG_LEVEL` | `INFO` | Logging level |
 | `AICM_LOG_BODIES` | `false` | Include request bodies in logs |
+| `AICM_LIMITS_ENABLED` | `false` | Enable triggered limit checks during delivery |
 
 \* If `AICM_DB_PATH` is set and `AICM_DELIVERY_TYPE` is not specified, the
 tracker defaults to `PERSISTENT_QUEUE`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,11 @@ def clear_triggered_limits(aicm_ini_path):
     if "triggered_limits" in cp:
         cp.remove_section("triggered_limits")
 
+    # Ensure triggered limits checks are enabled for tests that rely on them
+    if "tracker" not in cp:
+        cp.add_section("tracker")
+    cp["tracker"]["AICM_LIMITS_ENABLED"] = "true"
+
     # Write the cleaned config back
     os.makedirs(os.path.dirname(aicm_ini_path), exist_ok=True)
     with open(aicm_ini_path, "w") as f:

--- a/tests/test_delivery_triggered_limits.py
+++ b/tests/test_delivery_triggered_limits.py
@@ -49,6 +49,7 @@ def _setup_triggered_limits(ini_path):
     }
     cfg = ConfigManager(ini_path=str(ini_path))
     cfg.write_triggered_limits(item)
+    IniManager(str(ini_path)).set_option("tracker", "AICM_LIMITS_ENABLED", "true")
     return event
 
 


### PR DESCRIPTION
## Summary
- add `AICM_LIMITS_ENABLED` setting to control triggered limit enforcement
- gate delivery refresh/check logic on new config flag
- document new setting and update tests to enable it

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic` *(fails: Could not find a version that satisfies the requirement pydantic (Tunnel connection failed: 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_b_68a5a51af4e4832b9c123647ce6ea970