### PR TITLE
Add LLM client tracking wrappers

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -22,6 +22,13 @@ from .delivery import (
 )
 from .limits import BaseLimitManager, TriggeredLimitManager, UsageLimitManager
 from .tracker import Tracker
+from .wrappers import (
+    OpenAIChatWrapper,
+    OpenAIResponsesWrapper,
+    AnthropicWrapper,
+    GeminiWrapper,
+    BedrockWrapper,
+)
 
 __all__ = [
     "AICMError",
@@ -42,5 +49,10 @@ __all__ = [
     "BaseLimitManager",
     "TriggeredLimitManager",
     "UsageLimitManager",
+    "OpenAIChatWrapper",
+    "OpenAIResponsesWrapper",
+    "AnthropicWrapper",
+    "GeminiWrapper",
+    "BedrockWrapper",
     "__version__",
 ]

--- a/aicostmanager/wrappers.py
+++ b/aicostmanager/wrappers.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable, AsyncIterable
+from typing import Any
+
+from .tracker import Tracker
+from .usage_utils import get_usage_from_response, get_streaming_usage_from_response
+
+
+class _Proxy:
+    """Recursive proxy that intercepts method calls for tracking."""
+
+    def __init__(self, obj: Any, wrapper: "BaseLLMWrapper") -> None:
+        object.__setattr__(self, "_obj", obj)
+        object.__setattr__(self, "_wrapper", wrapper)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._obj, name)
+        if callable(attr):
+            if inspect.iscoroutinefunction(attr):
+                async def async_call(*args, **kwargs):
+                    model = self._wrapper._extract_model(attr, args, kwargs)
+                    result = await attr(*args, **kwargs)
+                    return await self._wrapper._handle_async_result(result, model)
+
+                return async_call
+            else:
+                def sync_call(*args, **kwargs):
+                    model = self._wrapper._extract_model(attr, args, kwargs)
+                    result = attr(*args, **kwargs)
+                    return self._wrapper._handle_result(result, model)
+
+                return sync_call
+        return _Proxy(attr, self._wrapper) if _should_wrap(attr) else attr
+
+    def __call__(self, *args, **kwargs):
+        model = self._wrapper._extract_model(self._obj, args, kwargs)
+        result = self._obj(*args, **kwargs)
+        return self._wrapper._handle_result(result, model)
+
+
+def _should_wrap(obj: Any) -> bool:
+    return not isinstance(
+        obj,
+        (
+            str,
+            bytes,
+            bytearray,
+            int,
+            float,
+            bool,
+            type(None),
+        ),
+    )
+
+
+class BaseLLMWrapper:
+    """Base wrapper that tracks usage for LLM SDK clients."""
+
+    api_id: str
+    vendor_name: str = ""
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        aicm_api_key: str | None = None,
+        tracker: Tracker | None = None,
+    ) -> None:
+        self._client = client
+        self._tracker = tracker or Tracker(aicm_api_key=aicm_api_key)
+        self._proxy = _Proxy(client, self)
+
+    # ------------------------------------------------------------------
+    def _extract_model(self, method: Any, args: tuple, kwargs: dict) -> str | None:
+        for key in ("model", "model_id", "modelId"):
+            if key in kwargs:
+                return kwargs[key]
+        try:
+            sig = inspect.signature(method)
+            params = list(sig.parameters)
+            for idx, name in enumerate(params):
+                if name in ("model", "model_id", "modelId") and idx < len(args):
+                    return args[idx]
+        except (ValueError, TypeError):
+            pass
+        return None
+
+    def _get_vendor(self) -> str:
+        return self.vendor_name
+
+    def _build_service_key(self, model: str | None) -> str:
+        vendor = self._get_vendor()
+        model_id = model or "unknown-model"
+        return f"{vendor}::{model_id}"
+
+    def _track_usage(self, response: Any, model: str | None) -> Any:
+        usage = get_usage_from_response(response, self.api_id)
+        if usage:
+            response_id = getattr(response, "id", None)
+            self._tracker.track(
+                self.api_id,
+                self._build_service_key(model),
+                usage,
+                response_id=response_id,
+            )
+        return response
+
+    def _wrap_stream(self, stream: Iterable, model: str | None) -> Iterable:
+        service_key = self._build_service_key(model)
+        usage_sent = False
+        for chunk in stream:
+            if not usage_sent:
+                usage = get_streaming_usage_from_response(chunk, self.api_id)
+                if usage:
+                    self._tracker.track(self.api_id, service_key, usage)
+                    usage_sent = True
+            yield chunk
+
+    async def _wrap_stream_async(self, stream: AsyncIterable, model: str | None):
+        service_key = self._build_service_key(model)
+        usage_sent = False
+        async for chunk in stream:
+            if not usage_sent:
+                usage = get_streaming_usage_from_response(chunk, self.api_id)
+                if usage:
+                    await self._tracker.track_async(
+                        self.api_id, service_key, usage
+                    )
+                    usage_sent = True
+            yield chunk
+
+    def _handle_result(self, result: Any, model: str | None):
+        if isinstance(result, AsyncIterable):
+            return self._wrap_stream_async(result, model)
+        if isinstance(result, Iterable) and not isinstance(
+            result, (str, bytes, bytearray, dict)
+        ):
+            return self._wrap_stream(result, model)
+        return self._track_usage(result, model)
+
+    async def _handle_async_result(self, result: Any, model: str | None):
+        if isinstance(result, AsyncIterable):
+            return self._wrap_stream_async(result, model)
+        if isinstance(result, Iterable) and not isinstance(
+            result, (str, bytes, bytearray, dict)
+        ):
+            return self._wrap_stream(result, model)
+        return self._track_usage(result, model)
+
+    # ------------------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:  # pragma: no cover - delegated
+        return getattr(self._proxy, name)
+
+    def close(self) -> None:  # pragma: no cover - simple passthrough
+        self._tracker.close()
+
+    def __del__(self):  # pragma: no cover - cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class OpenAIChatWrapper(BaseLLMWrapper):
+    api_id = "openai_chat"
+    vendor_name = "openai"
+
+    def _get_vendor(self) -> str:  # pragma: no cover - simple logic
+        base_url = getattr(self._client, "base_url", "")
+        if not base_url and hasattr(self._client, "client"):
+            base_url = getattr(self._client.client, "base_url", "")
+        if not base_url and hasattr(self._client, "_client"):
+            base_url = getattr(self._client._client, "base_url", "")
+        url = str(base_url).lower()
+        if "fireworks.ai" in url:
+            return "fireworks-ai"
+        if "x.ai" in url:
+            return "xai"
+        return "openai"
+
+
+class OpenAIResponsesWrapper(BaseLLMWrapper):
+    api_id = "openai_responses"
+    vendor_name = "openai"
+
+
+class AnthropicWrapper(BaseLLMWrapper):
+    api_id = "anthropic"
+    vendor_name = "anthropic"
+
+
+class GeminiWrapper(BaseLLMWrapper):
+    api_id = "gemini"
+    vendor_name = "google"
+
+
+class BedrockWrapper(BaseLLMWrapper):
+    api_id = "bedrock"
+    vendor_name = "amazon-bedrock"
+
+
+__all__ = [
+    "OpenAIChatWrapper",
+    "OpenAIResponsesWrapper",
+    "AnthropicWrapper",
+    "GeminiWrapper",
+    "BedrockWrapper",
+]

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ pass it directly to the client or tracker.
 
 - [Usage](usage.md) - Basic SDK usage and API examples
 - [Manual Usage Tracking](tracker.md) - Record custom usage events
+- [LLM Wrappers](llm_wrappers.md) - Drop-in clients that track usage automatically
 - [Configuration](config.md) - Settings and defaults
 - [Limit Managers](limit_managers.md) - Manage usage limits and triggered limits
 - [Django](django.md) - Integrate with Django projects

--- a/docs/llm_wrappers.md
+++ b/docs/llm_wrappers.md
@@ -1,0 +1,124 @@
+# LLM Wrappers
+
+AICostManager provides drop-in wrappers for popular large language model (LLM)
+SDK clients. Each wrapper embeds a :class:`~aicostmanager.tracker.Tracker`
+so every call automatically records usage without requiring any additional code.
+You continue to interact with the native client methods and properties while the
+wrapper forwards the usage data in the background.
+
+Wrappers automatically derive the ``service_key`` sent to the tracker from the
+model you pass to the underlying client. The corresponding ``api_id`` for the
+provider is built in.
+
+The service key format is ``[vendor]::[model]``. For the OpenAI Chat wrapper the
+vendor is inferred from the client's ``base_url`` so compatible providers like
+Fireworks or xAI are attributed correctly. The other wrappers use fixed vendors:
+``openai``, ``anthropic``, ``google`` and ``amazon-bedrock``.
+
+## Supported providers
+
+| Wrapper | Native client | ``api_id`` |
+| ------- | ------------- | ---------- |
+| ``OpenAIChatWrapper`` | ``openai.OpenAI`` | ``openai_chat`` |
+| ``OpenAIResponsesWrapper`` | ``openai.OpenAI`` | ``openai_responses`` |
+| ``AnthropicWrapper`` | ``anthropic.Anthropic`` | ``anthropic`` |
+| ``GeminiWrapper`` | ``google.generativeai.GenerativeModel`` | ``gemini`` |
+| ``BedrockWrapper`` | ``boto3.client('bedrock-runtime')`` | ``bedrock`` |
+
+## Basic usage
+
+```python
+from aicostmanager import OpenAIChatWrapper
+from openai import OpenAI
+
+client = OpenAI()
+wrapper = OpenAIChatWrapper(client)
+
+resp = wrapper.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Say hello"}],
+)
+print(resp.choices[0].message.content)
+
+wrapper.close()  # flush any queued tracking data
+```
+
+The wrapper proxies every attribute on the client, so existing code typically
+requires only one extra line to instantiate the wrapper.  A tracker is created
+internally using the ``AICM_API_KEY`` environment variable.  Pass ``aicm_api_key``
+or ``tracker`` to the wrapper constructor to override this behaviour.
+
+## Streaming responses
+
+Wrappers handle streaming automatically.  Iterate over the returned stream just
+as you would with the native client and usage will be tracked once the final
+chunk containing usage arrives.
+
+```python
+stream = wrapper.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Write a short poem"}],
+    stream=True,
+    stream_options={"include_usage": True},
+)
+
+for event in stream:
+    if event.type == "message.delta" and event.delta.get("content"):
+        print(event.delta["content"], end="")
+print()
+```
+
+## Asynchronous clients
+
+If the underlying SDK provides ``async`` methods, the wrappers preserve that
+behaviour:
+
+```python
+async def run():
+    resp = await wrapper.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    print(resp.choices[0].message.content)
+```
+
+Streaming async iterables are also supported and will be tracked in the same
+way.
+
+## Other providers
+
+Replace ``OpenAIChatWrapper`` with one of the other provider-specific wrappers
+and supply the appropriate native client:
+
+```python
+from aicostmanager import (
+    OpenAIResponsesWrapper,
+    AnthropicWrapper,
+    GeminiWrapper,
+    BedrockWrapper,
+)
+
+# OpenAI Responses
+resp_wrapper = OpenAIResponsesWrapper(client)
+resp_wrapper.responses.create(...)
+
+# Anthropic
+import anthropic
+anth_wrapper = AnthropicWrapper(anthropic.Anthropic())
+anth_wrapper.messages.create(model="claude-3-haiku-20240307", ...)
+
+# Gemini
+import google.generativeai as genai
+genai.configure()
+gem_wrapper = GeminiWrapper(genai.GenerativeModel("gemini-1.5-flash"))
+result = gem_wrapper.generate_content("hello")
+
+# Bedrock
+import boto3
+bed_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+bed_wrapper = BedrockWrapper(bed_client)
+bed_wrapper.invoke_model(modelId="anthropic.claude-v2", body={"prompt": "hi"})
+```
+
+The wrapper's ``close`` method should be invoked during application shutdown to
+ensure any buffered tracking data is delivered.

--- a/wrapper_tests/test_llm_wrappers.py
+++ b/wrapper_tests/test_llm_wrappers.py
@@ -1,0 +1,227 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+PACKAGE_DIR = Path(__file__).resolve().parent.parent / "aicostmanager"
+pkg = types.ModuleType("aicostmanager")
+pkg.__path__ = [str(PACKAGE_DIR)]
+sys.modules["aicostmanager"] = pkg
+
+# Provide a minimal Tracker stub to satisfy imports
+tracker_stub = types.ModuleType("aicostmanager.tracker")
+
+class Tracker:  # pragma: no cover - stub for tests
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def track(self, *args, **kwargs):
+        pass
+
+    async def track_async(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+tracker_stub.Tracker = Tracker
+sys.modules["aicostmanager.tracker"] = tracker_stub
+
+# Load usage_utils normally
+spec_usage = importlib.util.spec_from_file_location(
+    "aicostmanager.usage_utils", PACKAGE_DIR / "usage_utils.py"
+)
+usage_utils = importlib.util.module_from_spec(spec_usage)
+sys.modules["aicostmanager.usage_utils"] = usage_utils
+spec_usage.loader.exec_module(usage_utils)
+
+spec = importlib.util.spec_from_file_location(
+    "aicostmanager.wrappers", PACKAGE_DIR / "wrappers.py"
+)
+wrappers = importlib.util.module_from_spec(spec)
+sys.modules["aicostmanager.wrappers"] = wrappers
+spec.loader.exec_module(wrappers)
+
+OpenAIChatWrapper = wrappers.OpenAIChatWrapper
+OpenAIResponsesWrapper = wrappers.OpenAIResponsesWrapper
+AnthropicWrapper = wrappers.AnthropicWrapper
+GeminiWrapper = wrappers.GeminiWrapper
+BedrockWrapper = wrappers.BedrockWrapper
+
+
+class DummyTracker:
+    def __init__(self):
+        self.calls = []
+
+    def track(self, api_id, service_key, usage, **kwargs):
+        self.calls.append((api_id, service_key, usage))
+
+    async def track_async(self, api_id, service_key, usage, **kwargs):
+        self.calls.append((api_id, service_key, usage))
+
+    def close(self):
+        pass
+
+
+def _stream_chunk():
+    yield types.SimpleNamespace(usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
+    yield types.SimpleNamespace(data="done")
+
+
+def make_openai_chat_client(base_url: str | None = None):
+    class Completions:
+        def create(self, *args, **kwargs):
+            if kwargs.get("stream"):
+                return _stream_chunk()
+            return types.SimpleNamespace(
+                id="resp-1",
+                model=kwargs.get("model"),
+                usage={"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            )
+
+    class Chat:
+        completions = Completions()
+
+    class Client:
+        chat = Chat()
+
+    client = Client()
+    if base_url:
+        client.base_url = base_url
+    return client
+
+
+def make_openai_responses_client():
+    class Responses:
+        def create(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                id="resp-2",
+                model=kwargs.get("model"),
+                usage={"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            )
+
+    class Client:
+        responses = Responses()
+
+    return Client()
+
+
+def make_anthropic_client():
+    class Messages:
+        def create(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                id="resp-3",
+                usage={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            )
+
+    class Client:
+        messages = Messages()
+
+    return Client()
+
+
+def make_gemini_client():
+    class Models:
+        def generate_content(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                model=kwargs.get("model"),
+                usage_metadata={
+                    "promptTokenCount": 1,
+                    "candidatesTokenCount": 2,
+                    "totalTokenCount": 3,
+                },
+            )
+
+    class Client:
+        models = Models()
+
+    return Client()
+
+
+def make_bedrock_client():
+    class Client:
+        def invoke_model(self, *args, **kwargs):
+            return {
+                "usage": {
+                    "inputTokens": 1,
+                    "outputTokens": 2,
+                    "totalTokens": 3,
+                }
+            }
+
+    return Client()
+
+
+def test_wrappers_track_usage_non_streaming():
+    tracker = DummyTracker()
+    cases = [
+        (
+            OpenAIChatWrapper,
+            make_openai_chat_client(),
+            "chat.completions.create",
+            {"model": "gpt-4"},
+            "openai::gpt-4",
+        ),
+        (
+            OpenAIResponsesWrapper,
+            make_openai_responses_client(),
+            "responses.create",
+            {"model": "gpt-4"},
+            "openai::gpt-4",
+        ),
+        (
+            AnthropicWrapper,
+            make_anthropic_client(),
+            "messages.create",
+            {"model": "claude-3"},
+            "anthropic::claude-3",
+        ),
+        (
+            GeminiWrapper,
+            make_gemini_client(),
+            "models.generate_content",
+            {"model": "models/gemini"},
+            "google::models/gemini",
+        ),
+        (
+            BedrockWrapper,
+            make_bedrock_client(),
+            "invoke_model",
+            {"modelId": "anthropic.claude-v2"},
+            "amazon-bedrock::anthropic.claude-v2",
+        ),
+    ]
+    for wrapper_cls, client, call_path, kwargs, expected in cases:
+        tracker.calls.clear()
+        wrapper = wrapper_cls(client, tracker=tracker)
+        obj = wrapper
+        for attr in call_path.split('.'):
+            obj = getattr(obj, attr)
+        obj(**kwargs)
+        assert tracker.calls and tracker.calls[0][0] == wrapper_cls.api_id
+        assert tracker.calls[0][1] == expected
+
+
+def test_openai_chat_wrapper_streaming_tracks_once():
+    tracker = DummyTracker()
+    client = make_openai_chat_client()
+    wrapper = OpenAIChatWrapper(client, tracker=tracker)
+    stream = wrapper.chat.completions.create(model="gpt-4", stream=True)
+    list(stream)
+    assert tracker.calls and tracker.calls[0][0] == "openai_chat"
+    assert tracker.calls[0][1] == "openai::gpt-4"
+
+
+def test_openai_chat_vendor_detection():
+    tracker = DummyTracker()
+    fw_client = make_openai_chat_client("https://api.fireworks.ai")
+    wrapper_fw = OpenAIChatWrapper(fw_client, tracker=tracker)
+    wrapper_fw.chat.completions.create(model="m1")
+    assert tracker.calls[0][1] == "fireworks-ai::m1"
+
+    tracker.calls.clear()
+    x_client = make_openai_chat_client("https://api.x.ai")
+    wrapper_x = OpenAIChatWrapper(x_client, tracker=tracker)
+    wrapper_x.chat.completions.create(model="m2")
+    assert tracker.calls[0][1] == "xai::m2"

--- a/wrapper_tests/test_llm_wrappers_real.py
+++ b/wrapper_tests/test_llm_wrappers_real.py
@@ -1,0 +1,201 @@
+import os
+import pytest
+
+from aicostmanager.wrappers import (
+    OpenAIChatWrapper,
+    OpenAIResponsesWrapper,
+    AnthropicWrapper,
+    GeminiWrapper,
+    BedrockWrapper,
+)
+
+
+def _require_env(var: str) -> None:
+    if not os.getenv(var):
+        pytest.skip(f"{var} not set")
+
+
+def _call_or_skip(fn, msg: str) -> None:
+    try:
+        fn()
+    except Exception as exc:  # pragma: no cover - best effort
+        pytest.skip(f"{msg} failed: {exc}")
+
+
+def _setup_capture(wrapper):
+    calls = []
+    orig = wrapper._tracker.delivery.enqueue
+
+    def capture(payload):
+        calls.append(payload)
+        return orig(payload)
+
+    wrapper._tracker.delivery.enqueue = capture
+    return calls
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="avoid real API calls in CI")
+def test_openai_chat_real():
+    openai = pytest.importorskip("openai")
+    _require_env("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_TEST_MODEL", "gpt-3.5-turbo")
+    client = openai.OpenAI()
+    wrapper = OpenAIChatWrapper(client)
+    calls = _setup_capture(wrapper)
+
+    def non_stream():
+        wrapper.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    _call_or_skip(non_stream, "openai chat non-stream")
+    assert calls and calls[-1]["api_id"] == "openai_chat"
+    assert calls[-1]["service_key"] == f"openai::{model}"
+    calls.clear()
+
+    def stream():
+        stream = wrapper.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        for _ in stream:
+            pass
+
+    _call_or_skip(stream, "openai chat stream")
+    assert calls and calls[-1]["api_id"] == "openai_chat"
+    assert calls[-1]["service_key"] == f"openai::{model}"
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="avoid real API calls in CI")
+def test_openai_responses_real():
+    openai = pytest.importorskip("openai")
+    _require_env("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_TEST_MODEL", "gpt-3.5-turbo")
+    client = openai.OpenAI()
+    wrapper = OpenAIResponsesWrapper(client)
+    calls = _setup_capture(wrapper)
+
+    def non_stream():
+        wrapper.responses.create(
+            model=model,
+            input="hi",
+        )
+
+    _call_or_skip(non_stream, "openai responses non-stream")
+    assert calls and calls[-1]["api_id"] == "openai_responses"
+    assert calls[-1]["service_key"] == f"openai::{model}"
+    calls.clear()
+
+    def stream():
+        stream = wrapper.responses.create(
+            model=model,
+            input="hi",
+            stream=True,
+        )
+        for _ in stream:
+            pass
+
+    _call_or_skip(stream, "openai responses stream")
+    assert calls and calls[-1]["api_id"] == "openai_responses"
+    assert calls[-1]["service_key"] == f"openai::{model}"
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="avoid real API calls in CI")
+def test_anthropic_real():
+    anthropic = pytest.importorskip("anthropic")
+    _require_env("ANTHROPIC_API_KEY")
+    model = os.getenv("ANTHROPIC_MODEL", "claude-3-haiku-20240307")
+    client = anthropic.Anthropic()
+    wrapper = AnthropicWrapper(client)
+    calls = _setup_capture(wrapper)
+
+    def non_stream():
+        wrapper.messages.create(
+            model=model,
+            max_tokens=32,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    _call_or_skip(non_stream, "anthropic non-stream")
+    assert calls and calls[-1]["api_id"] == "anthropic"
+    assert calls[-1]["service_key"] == f"anthropic::{model}"
+    calls.clear()
+
+    def stream():
+        stream = wrapper.messages.create(
+            model=model,
+            max_tokens=32,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        for _ in stream:
+            pass
+
+    _call_or_skip(stream, "anthropic stream")
+    assert calls and calls[-1]["api_id"] == "anthropic"
+    assert calls[-1]["service_key"] == f"anthropic::{model}"
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="avoid real API calls in CI")
+def test_gemini_real():
+    genai = pytest.importorskip("google.generativeai")
+    _require_env("GOOGLE_API_KEY")
+    model = os.getenv("GEMINI_MODEL", "models/gemini-1.5-flash")
+    client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+    wrapper = GeminiWrapper(client)
+    calls = _setup_capture(wrapper)
+
+    def non_stream():
+        wrapper.models.generate_content(
+            model=model,
+            contents="hi",
+        )
+
+    _call_or_skip(non_stream, "gemini non-stream")
+    assert calls and calls[-1]["api_id"] == "gemini"
+    assert calls[-1]["service_key"] == f"google::{model}"
+    calls.clear()
+
+    def stream():
+        stream = wrapper.models.generate_content(
+            model=model,
+            contents="hi",
+            stream=True,
+        )
+        for _ in stream:
+            pass
+
+    _call_or_skip(stream, "gemini stream")
+    assert calls and calls[-1]["api_id"] == "gemini"
+    assert calls[-1]["service_key"] == f"google::{model}"
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="avoid real API calls in CI")
+def test_bedrock_real():
+    boto3 = pytest.importorskip("boto3")
+    if not (os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")):
+        pytest.skip("AWS credentials not set")
+    client = boto3.client("bedrock-runtime")
+    wrapper = BedrockWrapper(client)
+    calls = _setup_capture(wrapper)
+    model_id = os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-v2")
+    payload = '{"prompt":"hi","max_tokens_to_sample":32}'
+
+    def non_stream():
+        wrapper.invoke_model(modelId=model_id, body=payload)
+
+    _call_or_skip(non_stream, "bedrock non-stream")
+    assert calls and calls[-1]["api_id"] == "bedrock"
+    assert calls[-1]["service_key"] == f"amazon-bedrock::{model_id}"
+    calls.clear()
+
+    def stream():
+        stream = wrapper.invoke_model_with_response_stream(modelId=model_id, body=payload)
+        for _ in stream.get("body", []):
+            pass
+
+    _call_or_skip(stream, "bedrock stream")
+    assert calls and calls[-1]["api_id"] == "bedrock"
+    assert calls[-1]["service_key"] == f"amazon-bedrock::{model_id}"


### PR DESCRIPTION
## Summary
- add generic `BaseLLMWrapper` and provider-specific wrappers for OpenAI Chat, OpenAI Responses, Anthropic, Gemini and Bedrock clients
- expose new wrappers from the package init for easy import
- cover wrapper behavior with unit tests using dummy clients
- add optional integration tests that exercise real API clients when credentials are available
- real integration tests now use the default tracker instead of a stub to verify usage tracking
- document LLM wrappers and link them from the docs index
- derive service keys from the model passed to each LLM call and infer vendor for OpenAI Chat from the client's base URL

## Testing
- `pytest wrapper_tests/test_llm_wrappers.py wrapper_tests/test_llm_wrappers_real.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a849066cfc832bb2c381bbb99e54de