### PR TITLE
Refresh documentation and highlight LLM wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Configuration values are read from an ``AICM.INI`` file.  See
 [`config.md`](docs/config.md) for the complete list of available settings and
 their defaults.
 
+## LLM wrappers
+
+Wrap popular LLM SDK clients to record usage automatically without calling
+`track` manually:
+
+```python
+from aicostmanager import OpenAIChatWrapper
+from openai import OpenAI
+
+client = OpenAI()
+wrapper = OpenAIChatWrapper(client)
+
+resp = wrapper.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Say hello"}],
+)
+print(resp.choices[0].message.content)
+
+wrapper.close()  # flush any queued tracking data
+```
+
+See [LLM wrappers](docs/llm_wrappers.md) for the full list of supported
+providers and advanced usage.
+
 ## Choosing a delivery strategy
 
 `Tracker` supports multiple delivery components via `DeliveryType`:
@@ -105,7 +129,7 @@ app = FastAPI()
 
 @app.on_event("startup")
 async def startup() -> None:
-    app.state.tracker = await Tracker.create_async()
+    app.state.tracker = Tracker()
 
 @app.on_event("shutdown")
 def shutdown() -> None:
@@ -160,6 +184,7 @@ to ensure flushing.
 - [Usage Guide](docs/usage.md)
 - [Tracker](docs/tracker.md)
 - [Configuration](docs/config.md)
+- [LLM wrappers](docs/llm_wrappers.md)
 - [Persistent Delivery](docs/persistent_delivery.md)
 - [Django integration](docs/django.md)
 - [FastAPI integration](docs/fastapi.md)

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -32,8 +32,7 @@ export AICM_INI_PATH=/path/to/AICM.INI
 ## Application startup and shutdown
 
 Initialise the tracker during startup so configuration loading does not block
-individual requests. Use `Tracker.create_async` to perform setup in a worker
-thread and close the tracker on shutdown:
+individual requests and close the tracker on shutdown:
 
 ```python
 from fastapi import FastAPI
@@ -45,7 +44,7 @@ app = FastAPI()
 @app.on_event("startup")
 async def startup() -> None:
     ini_path = os.getenv("AICM_INI_PATH")
-    app.state.tracker = await Tracker.create_async(ini_path=ini_path)
+    app.state.tracker = Tracker(ini_path=ini_path)
 
 @app.on_event("shutdown")
 def shutdown() -> None:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ pass it directly to the client or tracker.
 ## User Guides
 
 - [Usage](usage.md) - Basic SDK usage and API examples
-- [Manual Usage Tracking](tracker.md) - Record custom usage events
+- [Tracker](tracker.md) - Record custom usage events
 - [LLM Wrappers](llm_wrappers.md) - Drop-in clients that track usage automatically
 - [Configuration](config.md) - Settings and defaults
 - [Limit Managers](limit_managers.md) - Manage usage limits and triggered limits

--- a/docs/persistent_delivery.md
+++ b/docs/persistent_delivery.md
@@ -17,9 +17,9 @@ Values can be supplied directly or through environment variables and the
 - `AICM_API_KEY`
 - `AICM_API_BASE` (default: `https://aicostmanager.com`)
 - `AICM_API_URL` (default: `/api/v1`)
-- `AICM_DELIVERY_DB_PATH`
-- `AICM_DELIVERY_LOG_FILE`
-- `AICM_DELIVERY_LOG_LEVEL`
+- `AICM_DB_PATH`
+- `AICM_LOG_FILE`
+- `AICM_LOG_LEVEL`
 - `AICM_LOG_BODIES`
 
 The same options may be placed in a `[delivery]` section inside the INI file.

--- a/docs/persistent_delivery_logging.md
+++ b/docs/persistent_delivery_logging.md
@@ -6,7 +6,7 @@
 
 ### Log Level
 
-Set the verbosity with the ``log_level`` parameter or ``AICM_DELIVERY_LOG_LEVEL`` environment variable.  The default is ``INFO``.  Use ``DEBUG`` to see detailed queue operations and worker activity.
+Set the verbosity with the ``log_level`` parameter or ``AICM_LOG_LEVEL`` environment variable.  The default is ``INFO``.  Use ``DEBUG`` to see detailed queue operations and worker activity.
 
 ```python
 from aicostmanager import PersistentDelivery
@@ -15,12 +15,12 @@ delivery = PersistentDelivery(log_level="DEBUG")
 ```
 
 ```bash
-export AICM_DELIVERY_LOG_LEVEL=DEBUG
+export AICM_LOG_LEVEL=DEBUG
 ```
 
 ### Log Destination
 
-By default logs are written to ``stdout`` via a ``StreamHandler``.  Provide ``log_file`` (or ``AICM_DELIVERY_LOG_FILE``) to write to a file instead.  The parent directory is created automatically.
+By default logs are written to ``stdout`` via a ``StreamHandler``.  Provide ``log_file`` (or ``AICM_LOG_FILE``) to write to a file instead.  The parent directory is created automatically.
 
 ```python
 delivery = PersistentDelivery(log_file="/var/log/aicm/delivery.log")
@@ -67,8 +67,8 @@ With ``log_level="DEBUG"`` the component records queue activity:
 
 ## Summary
 
-* ``log_level`` / ``AICM_DELIVERY_LOG_LEVEL`` – control verbosity
-* ``log_file`` / ``AICM_DELIVERY_LOG_FILE`` – write logs to a file
+* ``log_level`` / ``AICM_LOG_LEVEL`` – control verbosity
+* ``log_file`` / ``AICM_LOG_FILE`` – write logs to a file
 * ``logger`` – plug in a preconfigured ``Logger``
 * ``log_bodies`` / ``AICM_LOG_BODIES`` – log request/response bodies with redaction
 

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -100,7 +100,9 @@ async def track(payload: dict) -> dict:
 
 The tracker can derive token usage directly from OpenAI responses. Using the
 tracker as a context manager guarantees the usage is flushed before your
-program exits.
+program exits. If you prefer automatic tracking without calling these helper
+methods, see the [LLM wrappers](llm_wrappers.md) which proxy common SDK clients
+and record usage for you.
 
 ### Non-streaming example
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,7 @@ from aicostmanager import AsyncCostManagerClient
 You can override defaults when instantiating:
 
 ```python
-client = aicm(
+client = CostManagerClient(
     aicm_api_key="sk-api01-...",
     aicm_api_base="https://staging.aicostmanager.com",
     aicm_api_url="/api/v1",
@@ -54,15 +54,34 @@ for event in client.iter_usage_events(filters):
 
 ```
 
+## LLM wrappers
+
+Drop-in wrappers track usage automatically for popular LLM SDK clients:
+
+```python
+from aicostmanager import OpenAIChatWrapper
+from openai import OpenAI
+
+client = OpenAI()
+wrapper = OpenAIChatWrapper(client)
+resp = wrapper.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(resp.choices[0].message.content)
+wrapper.close()
+```
+
+See [LLM Wrappers](llm_wrappers.md) for the full list of supported providers.
+
 ## FastAPI integration
 
 See [Manual Usage Tracking](tracker.md) for a detailed guide on using the `Tracker` class.
 
 When recording custom usage with :class:`Tracker` in a FastAPI application,
 create the tracker during application startup so configuration loading doesn't
-block individual requests. The asynchronous factory ``Tracker.create_async``
-performs the initialization in a thread and returns a ready instance. During
-shutdown, stop the background delivery using ``Tracker.close``:
+block individual requests. During shutdown, stop the background delivery using
+``Tracker.close``:
 
 ```python
 from fastapi import FastAPI
@@ -73,7 +92,7 @@ app = FastAPI()
 
 @app.on_event("startup")
 async def startup() -> None:
-    app.state.tracker = await Tracker.create_async("cfg", "svc")
+    app.state.tracker = Tracker()
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- Document LLM wrappers in the README and usage guide with quick examples
- Remove references to deprecated `Tracker.create_async` and fix FastAPI snippets
- Correct environment variable names in persistent delivery docs and link tracker to wrappers

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68a8f4f535f4832b8b2064b92f74af99