### PR TITLE
Add Deepgram tests and documentation

### DIFF
--- a/docs/deepgram.md
+++ b/docs/deepgram.md
@@ -1,0 +1,49 @@
+# Deepgram
+
+AICostManager supports tracking usage for Deepgram's transcription and text to speech services.
+
+## Websocket transcription
+
+Use the `deepgram_websocket_transcription` service key to report websocket transcription usage. Payloads must include:
+
+- `model` – e.g. `nova-3` or `nova-2`
+- `language`
+- `duration` in seconds
+- optional `keywords` list for terms spotting
+
+Quantity is calculated as minutes (`duration / 60`). Cost units are configured per model and language combination, for example `nova-3-eng-wo-terms`, `nova-3-eng-w-terms`, `nova-3-multilingual`, and `nova-2`.
+
+Example:
+
+```python
+tracker.track(
+    "deepgram",
+    "deepgram::deepgram_websocket_transcription",
+    {"model": "nova-3", "language": "en", "duration": 120, "keywords": []},
+    response_id="dg-transcription-nova3-en-no-terms",
+    timestamp="2025-01-01T00:00:00Z",
+)
+```
+
+## Streaming text to speech
+
+The `deepgram_streaming_tts` service tracks Deepgram's streaming text to speech. Required fields:
+
+- `model`: `"aura-1"` or `"aura-2"`
+- `char_count`: number of characters synthesized
+
+Quantity is measured per thousand characters (`char_count / 1000`). Cost units are `text-to-speech-aura-1` and `text-to-speech-aura-2`.
+
+Example:
+
+```python
+tracker.track(
+    "deepgram",
+    "deepgram::deepgram_streaming_tts",
+    {"model": "aura-2", "char_count": 1500},
+    response_id="dg-tts-aura2-1500",
+    timestamp="2025-01-01T00:00:00Z",
+)
+```
+
+Both services work with immediate delivery or persistent queue delivery. When using a persistent queue, create the tracker inside a `with Tracker(...):` block to ensure any queued usage is flushed on exit.

--- a/tests/test_deepgram.py
+++ b/tests/test_deepgram.py
@@ -1,0 +1,208 @@
+import os
+import time
+import pytest
+
+from aicostmanager.delivery import DeliveryConfig, DeliveryType, create_delivery
+from aicostmanager.ini_manager import IniManager
+from aicostmanager.tracker import Tracker
+
+if os.environ.get("RUN_NETWORK_TESTS") != "1":
+    pytestmark = pytest.mark.skip(reason="requires network access")
+
+_SCENARIOS = [
+    (
+        "transcription_nova3_en_no_terms",
+        [
+            {
+                "response_id": "dg-transcription-nova3-en-no-terms",
+                "service_key": "deepgram::deepgram_websocket_transcription",
+                "payload": {
+                    "model": "nova-3",
+                    "language": "en",
+                    "duration": 120,
+                    "keywords": [],
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "transcription_nova3_en_with_terms",
+        [
+            {
+                "response_id": "dg-transcription-nova3-en-with-terms",
+                "service_key": "deepgram::deepgram_websocket_transcription",
+                "payload": {
+                    "model": "nova-3",
+                    "language": "en",
+                    "duration": 90,
+                    "keywords": ["brand", "product"],
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "transcription_nova3_multi",
+        [
+            {
+                "response_id": "dg-transcription-nova3-multi",
+                "service_key": "deepgram::deepgram_websocket_transcription",
+                "payload": {
+                    "model": "nova-3",
+                    "language": "multi",
+                    "duration": 45,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "transcription_fallback_nova2",
+        [
+            {
+                "response_id": "dg-transcription-fallback-nova2",
+                "service_key": "deepgram::deepgram_websocket_transcription",
+                "payload": {
+                    "model": "nova-2",
+                    "language": "en",
+                    "duration": 30,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "tts_aura1_500",
+        [
+            {
+                "response_id": "dg-tts-aura1-500",
+                "service_key": "deepgram::deepgram_streaming_tts",
+                "payload": {
+                    "model": "aura-1",
+                    "char_count": 500,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "tts_aura1_2500",
+        [
+            {
+                "response_id": "dg-tts-aura1-2500",
+                "service_key": "deepgram::deepgram_streaming_tts",
+                "payload": {
+                    "model": "aura-1",
+                    "char_count": 2500,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "tts_aura2_1000",
+        [
+            {
+                "response_id": "dg-tts-aura2-1000",
+                "service_key": "deepgram::deepgram_streaming_tts",
+                "payload": {
+                    "model": "aura-2",
+                    "char_count": 1000,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "tts_aura2_750",
+        [
+            {
+                "response_id": "dg-tts-aura2-750",
+                "service_key": "deepgram::deepgram_streaming_tts",
+                "payload": {
+                    "model": "aura-2",
+                    "char_count": 750,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            }
+        ],
+    ),
+    (
+        "mixed_batch",
+        [
+            {
+                "response_id": "dg-batch-transcription",
+                "service_key": "deepgram::deepgram_websocket_transcription",
+                "payload": {
+                    "model": "nova-3",
+                    "language": "en",
+                    "duration": 120,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+            {
+                "response_id": "dg-batch-tts",
+                "service_key": "deepgram::deepgram_streaming_tts",
+                "payload": {
+                    "model": "aura-1",
+                    "char_count": 1500,
+                },
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("events", [s[1] for s in _SCENARIOS], ids=[s[0] for s in _SCENARIOS])
+def test_deepgram_track_immediate(events, aicm_api_key, aicm_api_base, tmp_path):
+    ini = IniManager(str(tmp_path / "ini_immediate"))
+    dconfig = DeliveryConfig(
+        ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=aicm_api_base
+    )
+    delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+    with Tracker(
+        aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
+    ) as tracker:
+        for event in events:
+            result = tracker.track(
+                "deepgram",
+                event["service_key"],
+                event["payload"],
+                response_id=event["response_id"],
+                timestamp=event["timestamp"],
+            )
+            assert result["result"]["cost_events"]
+
+
+@pytest.mark.parametrize("events", [s[1] for s in _SCENARIOS], ids=[s[0] for s in _SCENARIOS])
+def test_deepgram_track_persistent(events, aicm_api_key, aicm_api_base, tmp_path):
+    ini = IniManager(str(tmp_path / "ini_persistent"))
+    dconfig = DeliveryConfig(
+        ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=aicm_api_base
+    )
+    delivery = create_delivery(
+        DeliveryType.PERSISTENT_QUEUE,
+        dconfig,
+        db_path=str(tmp_path / "queue.db"),
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    with Tracker(
+        aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
+    ) as tracker:
+        for event in events:
+            tracker.track(
+                "deepgram",
+                event["service_key"],
+                event["payload"],
+                response_id=event["response_id"],
+                timestamp=event["timestamp"],
+            )
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if delivery.stats().get("queued", 0) == 0:
+                break
+            time.sleep(0.1)
+        assert delivery.stats().get("queued", 0) == 0


### PR DESCRIPTION
## Summary
- add Deepgram transcription and text-to-speech tests for immediate and persistent delivery
- document Deepgram support for transcription and TTS

## Testing
- `pytest tests/test_deepgram.py -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68ab2294d58c832b8eb93335b29d75aa