### PR TITLE
Add HeyGen API tracking tests and documentation

### DIFF
--- a/docs/heygen.md
+++ b/docs/heygen.md
@@ -1,0 +1,56 @@
+# HeyGen
+
+AICostManager can track usage for HeyGen streaming sessions via the
+`streaming.list` endpoint.
+
+## Tracking streaming sessions
+
+Use `api_id` **"heygen"** and service key
+`heygen::api.heygen.com/v2/streaming.list`. Payloads require a
+`duration` field representing the session length in seconds. Billing is
+subject to a 30‑second minimum.
+
+```python
+from aicostmanager.delivery import DeliveryConfig, DeliveryType, create_delivery
+from aicostmanager.ini_manager import IniManager
+from aicostmanager.tracker import Tracker
+
+ini = IniManager("ini")
+dconfig = DeliveryConfig(ini_manager=ini, aicm_api_key="YOUR_AICM_KEY")
+delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+with Tracker(aicm_api_key="YOUR_AICM_KEY", ini_path=ini.ini_path, delivery=delivery) as tracker:
+    tracker.track(
+        "heygen",
+        "heygen::api.heygen.com/v2/streaming.list",
+        {"duration": 45},
+        response_id="heygen-session-uuid",
+        timestamp="2025-01-01T00:00:00Z",
+    )
+```
+
+## Persistent queue delivery
+
+To batch and retry delivery, use the persistent queue option:
+
+```python
+ini = IniManager("ini")
+dconfig = DeliveryConfig(ini_manager=ini, aicm_api_key="YOUR_AICM_KEY")
+queue_delivery = create_delivery(
+    DeliveryType.PERSISTENT_QUEUE,
+    dconfig,
+    db_path="queue.db",
+)
+
+with Tracker(aicm_api_key="YOUR_AICM_KEY", ini_path=ini.ini_path, delivery=queue_delivery) as tracker:
+    tracker.track(
+        "heygen",
+        "heygen::api.heygen.com/v2/streaming.list",
+        {"duration": 10},
+        response_id="heygen-batch-10s",
+        timestamp="2025-01-01T00:00:00Z",
+    )
+```
+
+The same service key and payload format can be used for batches of
+sessions. Durations shorter than 30 seconds will be billed as 30 seconds.

--- a/tests/test_heygen.py
+++ b/tests/test_heygen.py
@@ -1,0 +1,124 @@
+import datetime
+import os
+import time
+from typing import List, Dict
+
+import pytest
+import requests
+
+from aicostmanager.delivery import DeliveryConfig, DeliveryType, create_delivery
+from aicostmanager.ini_manager import IniManager
+from aicostmanager.tracker import Tracker
+
+SERVICE_KEY = "heygen::api.heygen.com/v2/streaming.list"
+BASE_URL = "https://api.heygen.com/v2/streaming.list"
+
+if os.environ.get("RUN_NETWORK_TESTS") != "1":
+    pytestmark = pytest.mark.skip(reason="requires network access")
+
+
+def _fetch_sessions(api_key: str, limit: int = 5) -> List[Dict[str, object]]:
+    """Fetch closed streaming sessions and convert them to track events."""
+    start = datetime.datetime(2025, 6, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime.now(datetime.timezone.utc)
+    headers = {"x-api-key": api_key, "accept": "application/json"}
+    params = {
+        "page": 1,
+        "page_size": min(limit, 100),
+        "date_from": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "date_to": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    events: List[Dict[str, object]] = []
+    while len(events) < limit:
+        resp = requests.get(BASE_URL, headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") and data.get("code") != 100:
+            raise RuntimeError(
+                f"HeyGen API returned error code {data.get('code')}: {data.get('message')}"
+            )
+        sessions = data.get("data") or []
+        for sess in sessions:
+            if sess.get("status") != "closed":
+                continue
+            created = datetime.datetime.fromtimestamp(
+                sess["created_at"], tz=datetime.timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            events.append(
+                {
+                    "response_id": sess["session_id"],
+                    "timestamp": created,
+                    "payload": {"duration": sess.get("duration", 0)},
+                }
+            )
+            if len(events) >= limit:
+                break
+        if len(events) >= limit or not data.get("next_page_token"):
+            break
+        params["page"] += 1
+    return events
+
+
+@pytest.fixture(scope="module")
+def heygen_events():
+    api_key = os.environ.get("HEYGEN_API_KEY")
+    if not api_key:
+        pytest.skip("HEYGEN_API_KEY not set in .env file")
+    try:
+        events = _fetch_sessions(api_key)
+    except Exception as exc:  # pragma: no cover - network issues
+        pytest.skip(f"HeyGen API call failed: {exc}")
+    if not events:
+        pytest.skip("No HeyGen sessions found for date range")
+    return events
+
+
+def test_heygen_track_immediate(heygen_events, aicm_api_key, aicm_api_base, tmp_path):
+    ini = IniManager(str(tmp_path / "heygen_immediate"))
+    dconfig = DeliveryConfig(
+        ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=aicm_api_base
+    )
+    delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+    with Tracker(
+        aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
+    ) as tracker:
+        for event in heygen_events:
+            result = tracker.track(
+                "heygen",
+                SERVICE_KEY,
+                event["payload"],
+                response_id=event["response_id"],
+                timestamp=event["timestamp"],
+            )
+            assert result["result"]["cost_events"]
+
+
+def test_heygen_track_persistent(heygen_events, aicm_api_key, aicm_api_base, tmp_path):
+    ini = IniManager(str(tmp_path / "heygen_persistent"))
+    dconfig = DeliveryConfig(
+        ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=aicm_api_base
+    )
+    delivery = create_delivery(
+        DeliveryType.PERSISTENT_QUEUE,
+        dconfig,
+        db_path=str(tmp_path / "heygen.db"),
+        poll_interval=0.1,
+        batch_interval=0.1,
+    )
+    with Tracker(
+        aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
+    ) as tracker:
+        for event in heygen_events:
+            tracker.track(
+                "heygen",
+                SERVICE_KEY,
+                event["payload"],
+                response_id=event["response_id"],
+                timestamp=event["timestamp"],
+            )
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if delivery.stats().get("queued", 0) == 0:
+                break
+            time.sleep(0.1)
+        assert delivery.stats().get("queued", 0) == 0


### PR DESCRIPTION
## Summary
- add tests that fetch HeyGen streaming sessions and track usage using both immediate and persistent delivery
- document how to track HeyGen costs using `heygen::api.heygen.com/v2/streaming.list`

## Testing
- `pytest tests/test_heygen.py -q` *(fails: No module named 'pydantic')*
- `pip install pydantic==1.10.15` *(fails: Could not find a version that satisfies the requirement pydantic==1.10.15 (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_b_68ab28f95684832bb53310bca8334241