### PR TITLE
Ensure delivery shutdown on Tracker close and persist stats

### DIFF
--- a/tests/test_deepgram.py
+++ b/tests/test_deepgram.py
@@ -226,9 +226,4 @@ def test_deepgram_track_persistent(events, aicm_api_key, aicm_api_base, tmp_path
                 response_id=event["response_id"],
                 timestamp=event["timestamp"],
             )
-        deadline = time.time() + 5
-        while time.time() < deadline:
-            if delivery.stats().get("queued", 0) == 0:
-                break
-            time.sleep(0.1)
-        assert delivery.stats().get("queued", 0) == 0
+    assert delivery.stats().get("queued", 0) == 0

--- a/tests/test_heygen.py
+++ b/tests/test_heygen.py
@@ -126,10 +126,4 @@ def test_heygen_track_persistent(heygen_events, aicm_api_key, aicm_api_base, tmp
                 response_id=event["response_id"],
                 timestamp=event["timestamp"],
             )
-    # Although stop() should be synchronous, add a brief wait to handle any race conditions
-    deadline = time.time() + 5
-    while time.time() < deadline:
-        if delivery.stats().get("queued", 0) == 0:
-            break
-        time.sleep(0.1)
     assert delivery.stats().get("queued", 0) == 0


### PR DESCRIPTION
## Summary
- Stop delivery unconditionally when closing a Tracker, avoiding lingering background workers.
- Preserve final statistics in PersistentDelivery so `stats()` is available after shutdown.
- Simplify persistent delivery tests by removing manual queue-drain waits.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ab302f5f64832bbb3b745c03d1c76b