### PR TITLE
feat: add cost query manager

### DIFF
--- a/aicostmanager/__init__.py
+++ b/aicostmanager/__init__.py
@@ -30,6 +30,7 @@ from .wrappers import (
     GeminiWrapper,
     BedrockWrapper,
 )
+from .costs import CostQueryManager
 
 __all__ = [
     "AICMError",
@@ -56,5 +57,6 @@ __all__ = [
     "AnthropicWrapper",
     "GeminiWrapper",
     "BedrockWrapper",
+    "CostQueryManager",
     "__version__",
 ]

--- a/aicostmanager/costs.py
+++ b/aicostmanager/costs.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, Optional
+
+from .client import CostManagerClient
+from .models import CostEvent, CostEventFilters, CostEventsResponse
+
+
+class CostQueryManager:
+    """Helper class for querying cost events from the API."""
+
+    def __init__(
+        self,
+        client: Optional[CostManagerClient] = None,
+        **client_kwargs: Any,
+    ) -> None:
+        """Create a :class:`CostQueryManager`.
+
+        Parameters
+        ----------
+        client:
+            Optional pre-configured :class:`~aicostmanager.client.CostManagerClient`.
+            If not provided, one will be created using ``client_kwargs``.
+        client_kwargs:
+            Keyword arguments forwarded to :class:`CostManagerClient` when ``client``
+            is not provided.
+        """
+
+        self.client = client or CostManagerClient(**client_kwargs)
+
+    def close(self) -> None:
+        """Close the underlying :class:`CostManagerClient` session."""
+
+        self.client.close()
+
+    def __enter__(self) -> "CostQueryManager":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def list_costs(
+        self,
+        filters: CostEventFilters | Dict[str, Any] | None = None,
+        **params: Any,
+    ) -> Any:
+        """Return raw cost event data from the ``/costs`` endpoint."""
+
+        if filters:
+            if hasattr(filters, "model_dump"):
+                params.update(filters.model_dump(exclude_none=True))
+            else:
+                params.update({k: v for k, v in filters.items() if v is not None})
+        return self.client._request("GET", "/costs/", params=params)
+
+    def list_costs_typed(
+        self,
+        filters: CostEventFilters | Dict[str, Any] | None = None,
+        **params: Any,
+    ) -> CostEventsResponse:
+        """Typed variant of :meth:`list_costs`."""
+
+        data = self.list_costs(filters, **params)
+        return CostEventsResponse.model_validate(data)
+
+    def iter_costs(
+        self,
+        filters: CostEventFilters | Dict[str, Any] | None = None,
+        **params: Any,
+    ) -> Iterator[CostEvent]:
+        """Iterate over cost events across paginated responses."""
+
+        if filters:
+            if hasattr(filters, "model_dump"):
+                params.update(filters.model_dump(exclude_none=True))
+            else:
+                params.update({k: v for k, v in filters.items() if v is not None})
+        for item in self.client._iter_paginated("/costs/", **params):
+            yield CostEvent.model_validate(item)

--- a/aicostmanager/models/__init__.py
+++ b/aicostmanager/models/__init__.py
@@ -20,6 +20,7 @@ from .usage import (
 from .customers import CustomerFilters, CustomerIn, CustomerOut
 from .limits import UsageLimitIn, UsageLimitOut, UsageLimitProgressOut
 from .services import CostUnitOut, ServiceOut, VendorOut
+from .costs import CostEvent, CostEventFilters, CostEventsResponse
 from .config import ServiceConfigItem, ServiceConfigListResponse
 
 __all__ = [
@@ -45,6 +46,9 @@ __all__ = [
     "CostUnitOut",
     "ServiceOut",
     "VendorOut",
+    "CostEvent",
+    "CostEventFilters",
+    "CostEventsResponse",
     "ServiceConfigItem",
     "ServiceConfigListResponse",
 ]

--- a/aicostmanager/models/costs.py
+++ b/aicostmanager/models/costs.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from .common import PaginatedResponse
+
+
+class CostEvent(BaseModel):
+    """Simplified cost event representation."""
+
+    vendor_id: str
+    service_id: str
+    cost_unit_id: str
+    quantity: Decimal
+    cost_per_unit: Decimal
+    cost: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CostEventFilters(BaseModel):
+    """Query parameters for ``list_costs``/``iter_costs``."""
+
+    response_id: Optional[str] = None
+    api_key_id: Optional[List[UUID]] = None
+    client_customer_key: Optional[List[str]] = None
+    service_key: Optional[List[str]] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class CostEventsResponse(PaginatedResponse[CostEvent]):
+    results: List[CostEvent] = []

--- a/docs/costs_query.md
+++ b/docs/costs_query.md
@@ -1,0 +1,83 @@
+# Querying Costs
+
+The :class:`~aicostmanager.costs.CostQueryManager` provides a lightweight way
+to retrieve cost events recorded by AICostManager. It wraps
+:class:`~aicostmanager.client.CostManagerClient` and exposes convenience
+methods for the ``/costs`` API.
+
+## Basic usage
+
+1. **Create a manager**
+
+   ```python
+   from aicostmanager import CostQueryManager
+
+   manager = CostQueryManager()  # reads AICM_API_KEY from the environment
+   ```
+
+2. **Construct query filters**
+
+   Filters can be provided as a dictionary or a
+   :class:`~aicostmanager.models.CostEventFilters` instance. All fields are
+   optional and correspond to the query parameters supported by the API.
+
+   ```python
+   from datetime import date
+   from aicostmanager.models import CostEventFilters
+
+   filters = CostEventFilters(
+       api_key_id=["11111111-2222-3333-4444-555555555555"],
+       service_key=["openai::gpt-4o"],
+       start_date=date(2025, 1, 1),
+       end_date=date(2025, 1, 31),
+       limit=50,
+   )
+   ```
+
+3. **Fetch results**
+
+   Use :meth:`list_costs_typed` for a typed paginated response or
+   :meth:`iter_costs` to stream individual events across all pages.
+
+   ```python
+   page = manager.list_costs_typed(filters)
+   print("total events:", page.count)
+   for event in page.results:
+       print(event.vendor_id, event.cost)
+
+   # or iterate through all pages
+   for event in manager.iter_costs(filters):
+       print(event.service_id, event.quantity)
+   ```
+
+4. **Context filters and pagination**
+
+   Additional context-based filters can be supplied using dictionary keys that
+   start with ``"context."``:
+
+   ```python
+   filters = {"context.project": "alpha", "limit": 25}
+   data = manager.list_costs(filters)
+   ```
+
+## Response data
+
+The API returns a paginated object with the following structure:
+
+- ``count`` – total number of matching events
+- ``next``/``previous`` – URLs for adjacent pages
+- ``results`` – list of cost events
+
+Each cost event includes:
+
+- ``vendor_id`` and ``service_id``
+- ``cost_unit_id``
+- ``quantity`` – number of units consumed
+- ``cost_per_unit`` – price for a single unit
+- ``cost`` – total cost for the event
+
+Close the manager when finished to release network resources:
+
+```python
+manager.close()
+```

--- a/tests/test_costs_query.py
+++ b/tests/test_costs_query.py
@@ -1,0 +1,110 @@
+from decimal import Decimal
+
+from aicostmanager import CostQueryManager
+from aicostmanager.models import CostEvent, CostEventFilters, CostEventsResponse
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self.status_code = 200
+        self.ok = True
+        self._data = data
+        self.headers = {"Content-Type": "application/json"}
+
+    def json(self):
+        return self._data
+
+
+def test_list_costs_typed(monkeypatch):
+    monkeypatch.setenv("AICM_API_KEY", "sk")
+    manager = CostQueryManager()
+
+    data = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "vendor_id": "v1",
+                "service_id": "s1",
+                "cost_unit_id": "cu1",
+                "quantity": "1",
+                "cost_per_unit": "0.01",
+                "cost": "0.01",
+            }
+        ],
+    }
+
+    captured = {}
+
+    def requester(self, method, url, **kwargs):
+        captured.update(kwargs.get("params", {}))
+        return DummyResponse(data)
+
+    monkeypatch.setattr("requests.Session.request", requester)
+
+    filters = CostEventFilters(response_id="resp_123")
+    resp = manager.list_costs_typed(filters)
+
+    assert isinstance(resp, CostEventsResponse)
+    assert isinstance(resp.results[0], CostEvent)
+    assert captured["response_id"] == "resp_123"
+
+
+def test_iter_costs(monkeypatch):
+    monkeypatch.setenv("AICM_API_KEY", "sk")
+    manager = CostQueryManager()
+
+    pages = [
+        {
+            "results": [
+                {
+                    "vendor_id": "v1",
+                    "service_id": "s1",
+                    "cost_unit_id": "cu1",
+                    "quantity": "1",
+                    "cost_per_unit": "0.01",
+                    "cost": "0.01",
+                }
+            ],
+            "next": manager.client.api_root + "/costs/?offset=1",
+        },
+        {
+            "results": [
+                {
+                    "vendor_id": "v2",
+                    "service_id": "s2",
+                    "cost_unit_id": "cu2",
+                    "quantity": "2",
+                    "cost_per_unit": "0.02",
+                    "cost": "0.04",
+                }
+            ],
+            "next": None,
+        },
+    ]
+
+    def requester(self, method, url, **kwargs):
+        return DummyResponse(pages.pop(0))
+
+    monkeypatch.setattr("requests.Session.request", requester)
+
+    events = list(manager.iter_costs())
+    assert [e.vendor_id for e in events] == ["v1", "v2"]
+    assert events[0].cost == Decimal("0.01")
+
+
+def test_list_costs_with_context_filters(monkeypatch):
+    monkeypatch.setenv("AICM_API_KEY", "sk")
+    manager = CostQueryManager()
+
+    captured = {}
+
+    def requester(self, method, url, **kwargs):
+        captured.update(kwargs.get("params", {}))
+        return DummyResponse({"count": 0, "next": None, "previous": None, "results": []})
+
+    monkeypatch.setattr("requests.Session.request", requester)
+
+    manager.list_costs({"context.environment": "prod"})
+    assert captured["context.environment"] == "prod"


### PR DESCRIPTION
## Summary
- add CostQueryManager for querying cost events with typed responses
- document how to use CostQueryManager
- test cost queries and pagination

## Testing
- `pytest tests/test_costs_query.py` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68ab4ae36bbc832b96847a3342ce5ca3