### PR TITLE
docs: clarify api identifiers and add curl examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,29 @@ pip install aicostmanager
 
 ## Quick start
 
+### Identify the API and service
+
+Every usage event is tied to two identifiers:
+
+- **api_id** – the API being called (for example, the OpenAI Chat API)
+- **service_key** – the specific model or service within that API
+
+1. Visit the [service lookup page](https://aicostmanager.com/services/lookup/) and
+   open the **APIs** tab. Copy the `api_id` for the API you are using, e.g.
+   `openai_chat`.
+2. Switch to the **Services** tab on the same page and copy the full
+   `service_key` for your model, e.g. `openai::gpt-5-mini`.
+
+### Track usage
+
 ```python
 from aicostmanager import Tracker
 
+api_id = "openai_chat"          # copied from the APIs tab
+service_key = "openai::gpt-5-mini"  # copied from the Services tab
+
 with Tracker() as tracker:
-    tracker.track("openai", "gpt-4o-mini", {
+    tracker.track(api_id, service_key, {
         "input_tokens": 10,
         "output_tokens": 20,
     })

--- a/docs/costs_query.md
+++ b/docs/costs_query.md
@@ -60,6 +60,29 @@ methods for the ``/costs`` API.
    data = manager.list_costs(filters)
    ```
 
+## Using curl
+
+Call the `/costs` endpoint directly with `curl` if you prefer raw HTTP:
+
+```bash
+curl https://api.aicostmanager.com/costs \
+  -H "Authorization: Bearer $AICM_API_KEY" \
+  -G \
+  --data-urlencode "service_key=openai::gpt-4o" \
+  --data-urlencode "limit=50"
+```
+
+Add context filters or date ranges as needed:
+
+```bash
+curl https://api.aicostmanager.com/costs \
+  -H "Authorization: Bearer $AICM_API_KEY" \
+  -G \
+  --data-urlencode "context.project=alpha" \
+  --data-urlencode "start_date=2025-01-01" \
+  --data-urlencode "end_date=2025-01-31"
+```
+
 ## Response data
 
 The API returns a paginated object with the following structure:


### PR DESCRIPTION
## Summary
- explain api_id and service_key lookup in README and show quick start with openai_chat/openai::gpt-5-mini
- add curl-based examples for querying costs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic` *(fails: 403 Forbidden when fetching pydantic)*

------
https://chatgpt.com/codex/tasks/task_b_68ab4cee5cd4832bbeafc67f79f5b986