### PR TITLE
Honor INI settings over environment variables

### DIFF
--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -24,18 +24,22 @@ class ImmediateDelivery(Delivery):
             def _get(option: str, default: str | None = None) -> str | None:
                 return ini_manager.get_option("tracker", option, default)
 
-            # Read configuration from environment variables and INI file
-            # Prefer environment variables if present (tests set AICM_API_BASE)
-            api_base = os.getenv("AICM_API_BASE") or _get(
-                "AICM_API_BASE", "https://aicostmanager.com"
+            # Read configuration from INI file, then environment variables, then defaults
+            api_base = (
+                _get("AICM_API_BASE")
+                or os.getenv("AICM_API_BASE")
+                or "https://aicostmanager.com"
             )
-            api_url = os.getenv("AICM_API_URL") or _get("AICM_API_URL", "/api/v1")
-            log_file = _get("AICM_LOG_FILE")
-            log_level = _get("AICM_LOG_LEVEL")
-            timeout = float(_get("AICM_TIMEOUT", "10.0"))
+            api_url = _get("AICM_API_URL") or os.getenv("AICM_API_URL") or "/api/v1"
+            log_file = _get("AICM_LOG_FILE") or os.getenv("AICM_LOG_FILE")
+            log_level = _get("AICM_LOG_LEVEL") or os.getenv("AICM_LOG_LEVEL")
+            timeout = float(
+                _get("AICM_TIMEOUT") or os.getenv("AICM_TIMEOUT") or "10.0"
+            )
             immediate_pause_seconds = float(
-                os.getenv("AICM_IMMEDIATE_PAUSE_SECONDS")
-                or _get("AICM_IMMEDIATE_PAUSE_SECONDS", "5.0")
+                _get("AICM_IMMEDIATE_PAUSE_SECONDS")
+                or os.getenv("AICM_IMMEDIATE_PAUSE_SECONDS")
+                or "5.0"
             )
 
             config = DeliveryConfig(

--- a/aicostmanager/delivery/persistent.py
+++ b/aicostmanager/delivery/persistent.py
@@ -39,18 +39,22 @@ class PersistentDelivery(QueueDelivery):
             def _get(option: str, default: str | None = None) -> str | None:
                 return ini_manager.get_option("tracker", option, default)
 
-            # Read configuration from environment variables and INI file
-            # Prefer environment variables if present (tests set AICM_API_BASE)
-            api_base = os.getenv("AICM_API_BASE") or _get(
-                "AICM_API_BASE", "https://aicostmanager.com"
+            # Read configuration from INI file, then environment variables, then defaults
+            api_base = (
+                _get("AICM_API_BASE")
+                or os.getenv("AICM_API_BASE")
+                or "https://aicostmanager.com"
             )
-            api_url = os.getenv("AICM_API_URL") or _get("AICM_API_URL", "/api/v1")
-            log_file = _get("AICM_LOG_FILE")
-            log_level = _get("AICM_LOG_LEVEL")
-            timeout = float(_get("AICM_TIMEOUT", "10.0"))
+            api_url = _get("AICM_API_URL") or os.getenv("AICM_API_URL") or "/api/v1"
+            log_file = _get("AICM_LOG_FILE") or os.getenv("AICM_LOG_FILE")
+            log_level = _get("AICM_LOG_LEVEL") or os.getenv("AICM_LOG_LEVEL")
+            timeout = float(
+                _get("AICM_TIMEOUT") or os.getenv("AICM_TIMEOUT") or "10.0"
+            )
             immediate_pause_seconds = float(
-                os.getenv("AICM_IMMEDIATE_PAUSE_SECONDS")
-                or _get("AICM_IMMEDIATE_PAUSE_SECONDS", "5.0")
+                _get("AICM_IMMEDIATE_PAUSE_SECONDS")
+                or os.getenv("AICM_IMMEDIATE_PAUSE_SECONDS")
+                or "5.0"
             )
 
             config = DeliveryConfig(

--- a/tests/test_delivery_config_precedence.py
+++ b/tests/test_delivery_config_precedence.py
@@ -1,0 +1,33 @@
+from aicostmanager.delivery import ImmediateDelivery, PersistentDelivery
+from aicostmanager.ini_manager import IniManager
+
+
+def test_immediate_ini_over_env(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    monkeypatch.setenv("AICM_INI_PATH", str(ini_path))
+    # Environment provides one value, INI overrides it
+    monkeypatch.setenv("AICM_API_BASE", "https://env.example")
+    monkeypatch.setenv("AICM_IMMEDIATE_PAUSE_SECONDS", "1")
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_API_BASE", "https://ini.example")
+    ini.set_option("tracker", "AICM_IMMEDIATE_PAUSE_SECONDS", "2")
+
+    delivery = ImmediateDelivery()
+
+    assert delivery.api_base == "https://ini.example"
+    assert delivery.immediate_pause_seconds == 2.0
+
+
+def test_persistent_ini_over_env(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    monkeypatch.setenv("AICM_INI_PATH", str(ini_path))
+    monkeypatch.setenv("AICM_API_BASE", "https://env.example")
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_API_BASE", "https://ini.example")
+
+    delivery = PersistentDelivery(db_path=str(tmp_path / "queue.db"))
+    try:
+        assert delivery.api_base == "https://ini.example"
+    finally:
+        delivery.stop()
+


### PR DESCRIPTION
## Summary
- Read delivery configuration from INI files before environment variables
- Add unit tests ensuring INI overrides environment variables

## Testing
- ⚠️ `pytest tests/test_delivery_config_precedence.py -q` *(missing dependency: pydantic)*

------
https://chatgpt.com/codex/tasks/task_b_68ab78bf6a14832b83dc1e4818ad5a35