### PR TITLE
Check env var for persistent db path

### DIFF
--- a/aicostmanager/delivery/persistent.py
+++ b/aicostmanager/delivery/persistent.py
@@ -70,11 +70,18 @@ class PersistentDelivery(QueueDelivery):
 
         # Create default db_path if none provided
         if db_path is None:
+            # Precedence: INI setting > environment variable > default path
             # Check if db_path was provided in config's INI file
             if hasattr(config, "ini_manager"):
                 ini_db_path = config.ini_manager.get_option("tracker", "AICM_DB_PATH")
                 if ini_db_path:
                     db_path = ini_db_path
+
+            # Fall back to environment variable
+            if db_path is None:
+                env_db_path = os.getenv("AICM_DB_PATH")
+                if env_db_path:
+                    db_path = env_db_path
 
             # If still None, use default cache directory
             if db_path is None:

--- a/tests/test_delivery_config_precedence.py
+++ b/tests/test_delivery_config_precedence.py
@@ -31,3 +31,18 @@ def test_persistent_ini_over_env(tmp_path, monkeypatch):
     finally:
         delivery.stop()
 
+
+def test_env_db_path_over_default(tmp_path, monkeypatch):
+    custom_db = tmp_path / "custom_queue.db"
+    monkeypatch.setenv("AICM_DB_PATH", str(custom_db))
+    monkeypatch.setenv("AICM_INI_PATH", str(tmp_path / "AICM.INI"))
+
+    delivery = PersistentDelivery()
+    try:
+        assert delivery.db_path == str(custom_db)
+        from pathlib import Path
+        default_db = Path.home() / ".cache" / "aicostmanager" / "delivery_queue.db"
+        assert delivery.db_path != str(default_db)
+    finally:
+        delivery.stop()
+


### PR DESCRIPTION
## Summary
- Allow `PersistentDelivery` to read database path from `AICM_DB_PATH` environment variable, after INI lookup and before defaulting
- Document precedence of INI, env var, then default path
- Add regression test ensuring environment variable overrides default DB path

## Testing
- `pytest tests/test_delivery_config_precedence.py::test_env_db_path_over_default -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic httpx PyJWT tenacity cryptography requests -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ab7a213bd0832b81322f52835f6a7c