### PR TITLE
Use INI before env for tracker options and add precedence tests

### DIFF
--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -35,13 +35,13 @@ class Tracker:
         self.aicm_api_key = aicm_api_key or os.getenv("AICM_API_KEY")
 
         def _get(option: str, default: str | None = None) -> str | None:
-            return self.ini_manager.get_option("tracker", option, default)
+            val = self.ini_manager.get_option("tracker", option)
+            if val is not None:
+                return val
+            return os.getenv(option, default)
 
-        # Prefer environment variables if present (tests set AICM_API_BASE)
-        api_base = os.getenv("AICM_API_BASE") or _get(
-            "AICM_API_BASE", "https://aicostmanager.com"
-        )
-        api_url = os.getenv("AICM_API_URL") or _get("AICM_API_URL", "/api/v1")
+        api_base = _get("AICM_API_BASE", "https://aicostmanager.com")
+        api_url = _get("AICM_API_URL", "/api/v1")
         db_path = _get("AICM_DB_PATH")
         log_file = _get("AICM_LOG_FILE")
         log_level = _get("AICM_LOG_LEVEL")
@@ -49,8 +49,7 @@ class Tracker:
         poll_interval = float(_get("AICM_POLL_INTERVAL", "0.1"))
         batch_interval = float(_get("AICM_BATCH_INTERVAL", "0.5"))
         immediate_pause_seconds = float(
-            os.getenv("AICM_IMMEDIATE_PAUSE_SECONDS")
-            or _get("AICM_IMMEDIATE_PAUSE_SECONDS", "5.0")
+            _get("AICM_IMMEDIATE_PAUSE_SECONDS", "5.0")
         )
         max_attempts = int(_get("AICM_MAX_ATTEMPTS", "3"))
         max_retries = int(_get("AICM_MAX_RETRIES", "5"))

--- a/tests/test_tracker_option_precedence.py
+++ b/tests/test_tracker_option_precedence.py
@@ -1,0 +1,54 @@
+from aicostmanager import Tracker
+from aicostmanager.ini_manager import IniManager
+
+
+def test_immediate_timeout_ini_over_env(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_TIMEOUT", "1.23")
+    monkeypatch.setenv("AICM_TIMEOUT", "9.87")
+
+    tracker = Tracker(aicm_api_key="test", ini_path=str(ini_path))
+    try:
+        assert tracker.delivery.timeout == 1.23
+    finally:
+        tracker.close()
+
+
+def test_immediate_timeout_env_over_default(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    IniManager(str(ini_path))
+    monkeypatch.setenv("AICM_TIMEOUT", "9.87")
+
+    tracker = Tracker(aicm_api_key="test", ini_path=str(ini_path))
+    try:
+        assert tracker.delivery.timeout == 9.87
+    finally:
+        tracker.close()
+
+
+def test_persistent_poll_interval_ini_over_env(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_DB_PATH", str(tmp_path / "queue.db"))
+    ini.set_option("tracker", "AICM_POLL_INTERVAL", "5.0")
+    monkeypatch.setenv("AICM_POLL_INTERVAL", "7.0")
+
+    tracker = Tracker(aicm_api_key="test", ini_path=str(ini_path))
+    try:
+        assert tracker.delivery.poll_interval == 5.0
+    finally:
+        tracker.close()
+
+
+def test_persistent_poll_interval_env_over_default(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_DB_PATH", str(tmp_path / "queue.db"))
+    monkeypatch.setenv("AICM_POLL_INTERVAL", "7.0")
+
+    tracker = Tracker(aicm_api_key="test", ini_path=str(ini_path))
+    try:
+        assert tracker.delivery.poll_interval == 7.0
+    finally:
+        tracker.close()


### PR DESCRIPTION
## Summary
- Resolve all tracker options using INI → environment → default precedence
- Remove environment-first comment and simplify option resolution
- Add tests covering option precedence for timeout and poll interval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic==2.3.0` *(fails: Could not find a version that satisfies the requirement pydantic==2.3.0)*

------
https://chatgpt.com/codex/tasks/task_b_68ab7b1eaf48832ba974b17b4f515644