### PR TITLE
Load API settings from INI before env vars

### DIFF
--- a/aicostmanager/client/base.py
+++ b/aicostmanager/client/base.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Optional
 
 from .exceptions import MissingConfiguration
+from ..ini_manager import IniManager
 
 
 class BaseClient:
-    """Shared initialization logic for SDK clients."""
+    """Shared initialization logic for SDK clients.
+
+    The ``api_base`` and ``api_url`` values are resolved in the following order:
+
+    1. Explicit ``aicm_api_base``/``aicm_api_url`` parameters
+    2. Values from ``AICM.INI`` (``tracker`` section)
+    3. Environment variables ``AICM_API_BASE``/``AICM_API_URL``
+    4. Defaults ``https://aicostmanager.com`` and ``/api/v1``
+    """
 
     def __init__(
         self,
@@ -18,16 +26,21 @@ class BaseClient:
         aicm_api_url: Optional[str] = None,
         aicm_ini_path: Optional[str] = None,
     ) -> None:
+        self.ini_manager = IniManager(IniManager.resolve_path(aicm_ini_path))
+        self.ini_path = self.ini_manager.ini_path
+
         self.api_key = aicm_api_key or os.getenv("AICM_API_KEY")
-        self.api_base = aicm_api_base or os.getenv(
+
+        def _get(option: str, default: str | None = None) -> str | None:
+            val = self.ini_manager.get_option("tracker", option)
+            if val is not None:
+                return val
+            return os.getenv(option, default)
+
+        self.api_base = aicm_api_base or _get(
             "AICM_API_BASE", "https://aicostmanager.com"
         )
-        self.api_url = aicm_api_url or os.getenv("AICM_API_URL", "/api/v1")
-        self.ini_path = (
-            aicm_ini_path
-            or os.getenv("AICM_INI_PATH")
-            or str(Path.home() / ".config" / "aicostmanager" / "AICM.INI")
-        )
+        self.api_url = aicm_api_url or _get("AICM_API_URL", "/api/v1")
         if not self.api_key:
             raise MissingConfiguration(
                 "API key not provided. Set AICM_API_KEY environment variable or pass aicm_api_key"

--- a/tests/test_base_client_config_precedence.py
+++ b/tests/test_base_client_config_precedence.py
@@ -1,0 +1,16 @@
+from aicostmanager.client.base import BaseClient
+from aicostmanager.ini_manager import IniManager
+
+
+def test_base_client_ini_over_env(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    monkeypatch.setenv("AICM_API_BASE", "https://env.example")
+    monkeypatch.setenv("AICM_API_URL", "/env")
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_API_BASE", "https://ini.example")
+    ini.set_option("tracker", "AICM_API_URL", "/ini")
+
+    client = BaseClient(aicm_api_key="key", aicm_ini_path=str(ini_path))
+
+    assert client.api_base == "https://ini.example"
+    assert client.api_url == "/ini"


### PR DESCRIPTION
## Summary
- initialize `IniManager` in `BaseClient` to pull API settings
- read `api_base` and `api_url` from INI before environment vars
- test INI precedence over environment for client config

## Testing
- `pip install pydantic requests httpx tenacity PyJWT cryptography -q` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_base_client_config_precedence.py -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68ab7c9290bc832b914ee23c38125d1c