### PR TITLE
Use IniManager resolve_path when no ini_path

### DIFF
--- a/aicostmanager/config_manager.py
+++ b/aicostmanager/config_manager.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Optional
 import jwt
 
 from .client import AICMError, CostManagerClient
+from .ini_manager import IniManager
 from .triggered_limits_cache import triggered_limits_cache
 from .utils.ini_utils import atomic_write, file_lock, safe_read_config
 
@@ -59,7 +60,9 @@ class ConfigManager:
             self._get_triggered_limits: Callable[[], dict] = client.get_triggered_limits
         else:
             if ini_path is None:
-                raise ValueError("ini_path must be provided if client is not given")
+                ini_path = IniManager.resolve_path()
+            if not ini_path:
+                raise ValueError("ini_path could not be resolved")
             self.ini_path = ini_path
             self._get_triggered_limits = get_triggered_limits or (lambda: {})
         if load:

--- a/tests/test_config_manager_env.py
+++ b/tests/test_config_manager_env.py
@@ -1,0 +1,11 @@
+from aicostmanager.config_manager import ConfigManager
+from aicostmanager.ini_manager import IniManager
+
+
+def test_env_var_overrides_default(monkeypatch, tmp_path):
+    default = IniManager.resolve_path()
+    env_path = tmp_path / "custom.ini"
+    monkeypatch.setenv("AICM_INI_PATH", str(env_path))
+    cfg = ConfigManager(load=False)
+    assert cfg.ini_path == str(env_path)
+    assert cfg.ini_path != default


### PR DESCRIPTION
## Summary
- Allow ConfigManager to resolve ini_path automatically via IniManager when no client is provided
- Add test ensuring AICM_INI_PATH overrides default ini file location

## Testing
- `pytest -q tests/test_config_manager_env.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68ab7eac76c0832bbb921dc1b5ee54a2