### PR TITLE
feat: rename log bodies env var and test

### DIFF
--- a/aicostmanager/delivery/factory.py
+++ b/aicostmanager/delivery/factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import os
 
 from .base import Delivery, DeliveryConfig, DeliveryType
 from .immediate import ImmediateDelivery
@@ -31,7 +32,14 @@ def create_delivery(delivery_type: DeliveryType, config: DeliveryConfig, **kwarg
         db_path = kwargs.get("db_path") or str(
             Path.home() / ".cache" / "aicostmanager" / "delivery_queue.db"
         )
-        log_bodies = kwargs.get("log_bodies", False)
+        log_bodies = kwargs.get("log_bodies")
+        if log_bodies is None:
+            env_val = os.getenv("AICM_LOG_BODIES") or os.getenv(
+                "AICM_DELIVERY_LOG_BODIES"
+            )
+            log_bodies = str(env_val).lower() in {"1", "true", "yes", "on"}
+        else:
+            log_bodies = bool(log_bodies)
         params = {
             "db_path": db_path,
             "poll_interval": kwargs.get("poll_interval", 0.1),

--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -54,7 +54,13 @@ class Tracker:
         max_attempts = int(_get("AICM_MAX_ATTEMPTS", "3"))
         max_retries = int(_get("AICM_MAX_RETRIES", "5"))
         max_batch_size = int(_get("AICM_MAX_BATCH_SIZE", "1000"))
-        log_bodies = _get("AICM_LOG_BODIES", "false").lower() in {
+        # ``AICM_DELIVERY_LOG_BODIES`` was the legacy environment variable name.
+        # Prefer the new ``AICM_LOG_BODIES`` but fall back to the old name for
+        # backward compatibility.
+        log_bodies_val = _get("AICM_LOG_BODIES") or _get(
+            "AICM_DELIVERY_LOG_BODIES", "false"
+        )
+        log_bodies = str(log_bodies_val).lower() in {
             "1",
             "true",
             "yes",

--- a/tests/test_anthropic_real_tracker.py
+++ b/tests/test_anthropic_real_tracker.py
@@ -92,7 +92,7 @@ def test_anthropic_tracker(
 ):
     if not anthropic_api_key:
         pytest.skip("ANTHROPIC_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager(str(tmp_path / "ini"))
     dconfig = DeliveryConfig(
         ini_manager=ini,
@@ -105,8 +105,9 @@ def test_anthropic_tracker(
         db_path=str(tmp_path / "anthropic_queue.db"),
         poll_interval=0.1,
         batch_interval=0.1,
-        log_bodies=True,
     )
+
+    assert delivery.log_bodies
     tracker = Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     )
@@ -140,6 +141,8 @@ def test_anthropic_tracker(
         aicm_api_base=BASE_URL,
     )
     delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+    assert delivery2.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
     ) as t2:

--- a/tests/test_gemini_real_tracker.py
+++ b/tests/test_gemini_real_tracker.py
@@ -119,7 +119,7 @@ def _extract_response_id(used_id, fallback):
 def test_gemini_tracker(service_key, model, google_api_key, aicm_api_key, tmp_path):
     if not google_api_key:
         pytest.skip("GOOGLE_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager(str(tmp_path / "ini"))
     dconfig = DeliveryConfig(
         ini_manager=ini,
@@ -132,8 +132,9 @@ def test_gemini_tracker(service_key, model, google_api_key, aicm_api_key, tmp_pa
         db_path=str(tmp_path / "gemini_queue.db"),
         poll_interval=0.1,
         batch_interval=0.1,
-        log_bodies=True,
     )
+
+    assert delivery.log_bodies
     tracker = Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     )
@@ -159,6 +160,8 @@ def test_gemini_tracker(service_key, model, google_api_key, aicm_api_key, tmp_pa
         aicm_api_base=BASE_URL,
     )
     delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+    assert delivery2.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
     ) as t2:

--- a/tests/test_openai_chat_real_tracker.py
+++ b/tests/test_openai_chat_real_tracker.py
@@ -46,7 +46,7 @@ def test_openai_chat_tracker(
     api_key = os.environ.get(key_env)
     if not api_key:
         pytest.skip(f"{key_env} not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager(str(tmp_path / "ini"))
     dconfig = DeliveryConfig(
         ini_manager=ini,
@@ -54,6 +54,8 @@ def test_openai_chat_tracker(
         aicm_api_base=BASE_URL,
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     client = maker(api_key)
 
     # Immediate delivery using context manager
@@ -86,6 +88,8 @@ def test_openai_chat_tracker(
         aicm_api_base=BASE_URL,
     )
     delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+    assert delivery2.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
     ) as t2:

--- a/tests/test_openai_responses_real_tracker.py
+++ b/tests/test_openai_responses_real_tracker.py
@@ -35,7 +35,7 @@ def test_openai_responses_tracker(
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
     # Ensure PersistentDelivery logs request/response bodies from the server
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager(str(tmp_path / "ini"))
     dconfig = DeliveryConfig(
         ini_manager=ini,
@@ -48,8 +48,9 @@ def test_openai_responses_tracker(
         db_path=str(tmp_path / "openai_responses_queue.db"),
         poll_interval=0.1,
         batch_interval=0.1,
-        log_bodies=True,
     )
+
+    assert delivery.log_bodies
     tracker = Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     )
@@ -74,6 +75,8 @@ def test_openai_responses_tracker(
         aicm_api_base=BASE_URL,
     )
     delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+    assert delivery2.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
     ) as t2:

--- a/tests/tracker/deliver_now_nonstreaming/test_anthropic_deliver_now_only.py
+++ b/tests/tracker/deliver_now_nonstreaming/test_anthropic_deliver_now_only.py
@@ -63,12 +63,14 @@ def test_anthropic_deliver_now_only(
 ):
     if not anthropic_api_key:
         pytest.skip("ANTHROPIC_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager(str(tmp_path / "ini"))
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker/deliver_now_nonstreaming/test_bedrock_deliver_now_only.py
+++ b/tests/tracker/deliver_now_nonstreaming/test_bedrock_deliver_now_only.py
@@ -68,12 +68,14 @@ def _make_client(region: str):
 def test_bedrock_deliver_now_only(service_key, model, aws_region, aicm_api_key):
     if not aws_region:
         pytest.skip("AWS_DEFAULT_REGION not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker/deliver_now_nonstreaming/test_gemini_deliver_now_only.py
+++ b/tests/tracker/deliver_now_nonstreaming/test_gemini_deliver_now_only.py
@@ -145,12 +145,14 @@ def _wait_for_cost_event(aicm_api_key: str, response_id: str):
 def test_gemini_deliver_now_only(service_key, model, google_api_key, aicm_api_key):
     if not google_api_key:
         pytest.skip("GOOGLE_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     response_id = None
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery

--- a/tests/tracker/deliver_now_nonstreaming/test_openai_chat_deliver_now_only.py
+++ b/tests/tracker/deliver_now_nonstreaming/test_openai_chat_deliver_now_only.py
@@ -63,12 +63,14 @@ def test_openai_chat_deliver_now_only(service_key, model, key_env, maker, aicm_a
     api_key = os.environ.get(key_env)
     if not api_key:
         pytest.skip(f"{key_env} not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker/deliver_now_nonstreaming/test_openai_responses_deliver_now_only.py
+++ b/tests/tracker/deliver_now_nonstreaming/test_openai_responses_deliver_now_only.py
@@ -60,12 +60,14 @@ def test_openai_responses_deliver_now_only(
 ):
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker/deliver_now_streaming/test_anthropic_deliver_now_streaming.py
+++ b/tests/tracker/deliver_now_streaming/test_anthropic_deliver_now_streaming.py
@@ -63,7 +63,7 @@ def test_anthropic_deliver_now_streaming(
 ):
     if not anthropic_api_key:
         pytest.skip("ANTHROPIC_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -71,6 +71,8 @@ def test_anthropic_deliver_now_streaming(
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -109,6 +111,8 @@ def test_anthropic_deliver_now_streaming(
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker/deliver_now_streaming/test_bedrock_deliver_now_streaming.py
+++ b/tests/tracker/deliver_now_streaming/test_bedrock_deliver_now_streaming.py
@@ -68,7 +68,7 @@ def _make_client(region: str):
 def test_bedrock_deliver_now_streaming(service_key, model, aws_region, aicm_api_key):
     if not aws_region:
         pytest.skip("AWS_DEFAULT_REGION not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -76,6 +76,8 @@ def test_bedrock_deliver_now_streaming(service_key, model, aws_region, aicm_api_
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -138,6 +140,8 @@ def test_bedrock_deliver_now_streaming(service_key, model, aws_region, aicm_api_
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker/deliver_now_streaming/test_gemini_deliver_now_streaming.py
+++ b/tests/tracker/deliver_now_streaming/test_gemini_deliver_now_streaming.py
@@ -59,7 +59,7 @@ def _wait_for_cost_event(aicm_api_key: str, response_id: str):
 def test_gemini_deliver_now_streaming(service_key, model, google_api_key, aicm_api_key):
     if not google_api_key:
         pytest.skip("GOOGLE_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -67,6 +67,8 @@ def test_gemini_deliver_now_streaming(service_key, model, google_api_key, aicm_a
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -126,6 +128,8 @@ def test_gemini_deliver_now_streaming(service_key, model, google_api_key, aicm_a
                 ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
             )
             delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+            assert delivery2.log_bodies
             with Tracker(
                 aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
             ) as t2:

--- a/tests/tracker/deliver_now_streaming/test_openai_chat_deliver_now_streaming.py
+++ b/tests/tracker/deliver_now_streaming/test_openai_chat_deliver_now_streaming.py
@@ -60,7 +60,7 @@ def test_openai_chat_deliver_now_streaming(
 ):
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -68,6 +68,8 @@ def test_openai_chat_deliver_now_streaming(
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -101,6 +103,8 @@ def test_openai_chat_deliver_now_streaming(
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker/deliver_now_streaming/test_openai_responses_deliver_now_streaming.py
+++ b/tests/tracker/deliver_now_streaming/test_openai_responses_deliver_now_streaming.py
@@ -63,7 +63,7 @@ def test_openai_responses_deliver_now_streaming(
 ):
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -71,6 +71,8 @@ def test_openai_responses_deliver_now_streaming(
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -107,6 +109,8 @@ def test_openai_responses_deliver_now_streaming(
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker_async/deliver_now_nonstreaming/test_anthropic_deliver_now_only.py
+++ b/tests/tracker_async/deliver_now_nonstreaming/test_anthropic_deliver_now_only.py
@@ -64,12 +64,14 @@ def test_anthropic_deliver_now_only(
 ):
     if not anthropic_api_key:
         pytest.skip("ANTHROPIC_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager(str(tmp_path / "ini"))
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker_async/deliver_now_nonstreaming/test_bedrock_deliver_now_only.py
+++ b/tests/tracker_async/deliver_now_nonstreaming/test_bedrock_deliver_now_only.py
@@ -69,12 +69,14 @@ def _make_client(region: str):
 def test_bedrock_deliver_now_only(service_key, model, aws_region, aicm_api_key):
     if not aws_region:
         pytest.skip("AWS_DEFAULT_REGION not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker_async/deliver_now_nonstreaming/test_gemini_deliver_now_only.py
+++ b/tests/tracker_async/deliver_now_nonstreaming/test_gemini_deliver_now_only.py
@@ -146,12 +146,14 @@ def _wait_for_cost_event(aicm_api_key: str, response_id: str):
 def test_gemini_deliver_now_only(service_key, model, google_api_key, aicm_api_key):
     if not google_api_key:
         pytest.skip("GOOGLE_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker_async/deliver_now_nonstreaming/test_openai_chat_deliver_now_only.py
+++ b/tests/tracker_async/deliver_now_nonstreaming/test_openai_chat_deliver_now_only.py
@@ -64,12 +64,14 @@ def test_openai_chat_deliver_now_only(service_key, model, key_env, maker, aicm_a
     api_key = os.environ.get(key_env)
     if not api_key:
         pytest.skip(f"{key_env} not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker_async/deliver_now_nonstreaming/test_openai_responses_deliver_now_only.py
+++ b/tests/tracker_async/deliver_now_nonstreaming/test_openai_responses_deliver_now_only.py
@@ -61,12 +61,14 @@ def test_openai_responses_deliver_now_only(
 ):
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
     )
     delivery = create_delivery(DeliveryType.IMMEDIATE, dconfig)
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:

--- a/tests/tracker_async/deliver_now_streaming/test_anthropic_deliver_now_streaming.py
+++ b/tests/tracker_async/deliver_now_streaming/test_anthropic_deliver_now_streaming.py
@@ -64,7 +64,7 @@ def test_anthropic_deliver_now_streaming(
 ):
     if not anthropic_api_key:
         pytest.skip("ANTHROPIC_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -72,6 +72,8 @@ def test_anthropic_deliver_now_streaming(
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -110,6 +112,8 @@ def test_anthropic_deliver_now_streaming(
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker_async/deliver_now_streaming/test_bedrock_deliver_now_streaming.py
+++ b/tests/tracker_async/deliver_now_streaming/test_bedrock_deliver_now_streaming.py
@@ -69,7 +69,7 @@ def _make_client(region: str):
 def test_bedrock_deliver_now_streaming(service_key, model, aws_region, aicm_api_key):
     if not aws_region:
         pytest.skip("AWS_DEFAULT_REGION not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -77,6 +77,8 @@ def test_bedrock_deliver_now_streaming(service_key, model, aws_region, aicm_api_
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -139,6 +141,8 @@ def test_bedrock_deliver_now_streaming(service_key, model, aws_region, aicm_api_
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker_async/deliver_now_streaming/test_gemini_deliver_now_streaming.py
+++ b/tests/tracker_async/deliver_now_streaming/test_gemini_deliver_now_streaming.py
@@ -60,7 +60,7 @@ def _wait_for_cost_event(aicm_api_key: str, response_id: str):
 def test_gemini_deliver_now_streaming(service_key, model, google_api_key, aicm_api_key):
     if not google_api_key:
         pytest.skip("GOOGLE_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -68,6 +68,8 @@ def test_gemini_deliver_now_streaming(service_key, model, google_api_key, aicm_a
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -127,6 +129,8 @@ def test_gemini_deliver_now_streaming(service_key, model, google_api_key, aicm_a
                 ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
             )
             delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+            assert delivery2.log_bodies
             with Tracker(
                 aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
             ) as t2:

--- a/tests/tracker_async/deliver_now_streaming/test_openai_chat_deliver_now_streaming.py
+++ b/tests/tracker_async/deliver_now_streaming/test_openai_chat_deliver_now_streaming.py
@@ -61,7 +61,7 @@ def test_openai_chat_deliver_now_streaming(
 ):
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -69,6 +69,8 @@ def test_openai_chat_deliver_now_streaming(
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -102,6 +104,8 @@ def test_openai_chat_deliver_now_streaming(
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:

--- a/tests/tracker_async/deliver_now_streaming/test_openai_responses_deliver_now_streaming.py
+++ b/tests/tracker_async/deliver_now_streaming/test_openai_responses_deliver_now_streaming.py
@@ -64,7 +64,7 @@ def test_openai_responses_deliver_now_streaming(
 ):
     if not openai_api_key:
         pytest.skip("OPENAI_API_KEY not set in .env file")
-    os.environ["AICM_DELIVERY_LOG_BODIES"] = "true"
+    os.environ["AICM_LOG_BODIES"] = "true"
     ini = IniManager("ini")
     dconfig = DeliveryConfig(
         ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
@@ -72,6 +72,8 @@ def test_openai_responses_deliver_now_streaming(
     delivery = create_delivery(
         DeliveryType.PERSISTENT_QUEUE, dconfig, poll_interval=0.1, batch_interval=0.1
     )
+
+    assert delivery.log_bodies
     with Tracker(
         aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery
     ) as tracker:
@@ -108,6 +110,8 @@ def test_openai_responses_deliver_now_streaming(
             ini_manager=ini, aicm_api_key=aicm_api_key, aicm_api_base=BASE_URL
         )
         delivery2 = create_delivery(DeliveryType.IMMEDIATE, dconfig2)
+
+        assert delivery2.log_bodies
         with Tracker(
             aicm_api_key=aicm_api_key, ini_path=ini.ini_path, delivery=delivery2
         ) as t2:


### PR DESCRIPTION
## Summary
- support legacy AICM_DELIVERY_LOG_BODIES env var while preferring AICM_LOG_BODIES
- update delivery factory to honor log body env variables
- update tests to use AICM_LOG_BODIES and assert log body logging is enabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68aba79dd268832b855af76bd737bd90