### PR TITLE
feat: add queue monitor cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ unacceptable and immediate delivery when every call can block on the API. See
 [Persistent Delivery](docs/persistent_delivery.md) and the
 [Tracker guide](docs/tracker.md#choosing-a-delivery-manager) for details.
 
+For real-time insight into the persistent queue, run the `queue-monitor`
+command against the SQLite database created by `PersistentDelivery`:
+
+```
+uv run queue-monitor ~/.cache/aicostmanager/delivery_queue.db
+```
+
 ## Tracking in different environments
 
 ### Python scripts

--- a/aicostmanager/queue_monitor.py
+++ b/aicostmanager/queue_monitor.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
-"""Monitor a persistent delivery queue.
+"""Console script for monitoring a persistent delivery queue.
 
-This script polls the SQLite database used by
-:class:`aicostmanager.delivery.PersistentDelivery` and displays
-queue statistics along with recent failures. It is intended for
-manual monitoring in a separate terminal during development.
+This module exposes a :func:`main` function used by the
+``queue-monitor`` entry point. It polls the SQLite database used by
+:class:`aicostmanager.delivery.PersistentDelivery` and displays queue
+statistics along with recent failures. It is intended for manual
+monitoring in a separate terminal during development.
 """
 
 import argparse

--- a/docs/persistent_delivery.md
+++ b/docs/persistent_delivery.md
@@ -111,3 +111,11 @@ print(mgr.stats())
 
 `PersistentDelivery` logs a warning on startup if failed items are present and
 refers to this tool for remediation.
+
+For real-time monitoring during development, the package includes a small
+`queue-monitor` CLI that continuously prints queue statistics and recent
+failures:
+
+```
+uv run queue-monitor /path/to/queue.db
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 Homepage = "https://aicostmanager.com"
 Source = "https://github.com/aicostmanager/aicostmanager-python"
 
+[project.scripts]
+queue-monitor = "aicostmanager.queue_monitor:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["tests*", "scripts*", "docs*", "dist*", "build*"]


### PR DESCRIPTION
## Summary
- add `queue-monitor` entry point to monitor persistent delivery queue
- document `queue-monitor` CLI usage

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_b_68abaec361f8832b91da45612baecd76