### PR TITLE
chore: remove outdated delivery env variable reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,6 @@ All notable changes to this project will be documented in this file.
 - Async factory method `Tracker.create_async()` for non-blocking tracker initialization in async applications
 - `Tracker.close()` method for graceful shutdown of background delivery workers
 - Enhanced delivery queue with overflow metrics and configurable discard callbacks
-- Support for `AICM_DELIVERY_ON_FULL` environment variable to control queue overflow behavior globally
 
 ### Enhanced
 - **Manual usage tracking capabilities** with schema-based validation for custom usage scenarios


### PR DESCRIPTION
## Summary
- remove obsolete mention of `AICM_DELIVERY_ON_FULL` from changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic -q` *(fails: Could not find a version that satisfies the requirement pydantic, proxy 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b055873a08832b9dc7fd3e0b527cb4