### PR TITLE
Add default paths and support delivery type override

### DIFF
--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict
+from pathlib import Path
 
 from ..client.exceptions import NoCostsTrackedException, UsageLimitExceeded
 from ..config_manager import ConfigManager
@@ -22,6 +23,7 @@ class ImmediateDelivery(Delivery):
             from ..ini_manager import IniManager
 
             ini_manager = IniManager(IniManager.resolve_path(None))
+            ini_dir = Path(ini_manager.ini_path).resolve().parent
 
             def _get(option: str, default: str | None = None) -> str | None:
                 return ini_manager.get_option("tracker", option, default)
@@ -33,9 +35,15 @@ class ImmediateDelivery(Delivery):
                 or "https://aicostmanager.com"
             )
             api_url = _get("AICM_API_URL") or os.getenv("AICM_API_URL") or "/api/v1"
-            log_file = _get("AICM_LOG_FILE") or os.getenv("AICM_LOG_FILE")
+            log_file = (
+                _get("AICM_LOG_FILE")
+                or os.getenv("AICM_LOG_FILE")
+                or str(ini_dir / "aicm.log")
+            )
             log_level = _get("AICM_LOG_LEVEL") or os.getenv("AICM_LOG_LEVEL")
-            timeout = float(_get("AICM_TIMEOUT") or os.getenv("AICM_TIMEOUT") or "10.0")
+            timeout = float(
+                _get("AICM_TIMEOUT") or os.getenv("AICM_TIMEOUT") or "10.0"
+            )
             immediate_pause_seconds = float(
                 _get("AICM_IMMEDIATE_PAUSE_SECONDS")
                 or os.getenv("AICM_IMMEDIATE_PAUSE_SECONDS")

--- a/aicostmanager/wrappers.py
+++ b/aicostmanager/wrappers.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import AsyncIterable, Iterable, Iterator
 from typing import Any
 
+from .delivery import DeliveryType
 from .tracker import Tracker
 from .usage_utils import get_streaming_usage_from_response, get_usage_from_response
 
@@ -118,9 +119,12 @@ class BaseLLMWrapper:
         tracker: Tracker | None = None,
         client_customer_key: str | None = None,
         context: dict[str, Any] | None = None,
+        delivery_type: DeliveryType | str | None = None,
     ) -> None:
         self._client = client
-        self._tracker = tracker or Tracker(aicm_api_key=aicm_api_key)
+        self._tracker = tracker or Tracker(
+            aicm_api_key=aicm_api_key, delivery_type=delivery_type
+        )
         self._proxy = _Proxy(client, self)
         self.client_customer_key = client_customer_key
         self.context = context

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,21 +14,22 @@ All configuration keys are fully capitalised and prefixed with `AICM_`.
 
 | Setting | Default | Description |
 | --- | --- | --- |
+| `AICM_API_KEY` | – | API key used for authentication |
+| `AICM_INI_PATH` | `~/.config/aicostmanager/AICM.INI` | Path to INI configuration |
 | `AICM_API_BASE` | `https://aicostmanager.com` | Base URL for the API |
 | `AICM_API_URL` | `/api/v1` | API path prefix |
-| `AICM_DELIVERY_TYPE` | `IMMEDIATE`* | Delivery strategy (`IMMEDIATE`, `PERSISTENT_QUEUE`) |
-| `AICM_DB_PATH` | – | Path to SQLite database for persistent queue |
+| `AICM_DELIVERY_TYPE` | `IMMEDIATE` | Delivery strategy (`IMMEDIATE`, `PERSISTENT_QUEUE`) |
+| `AICM_DB_PATH` | `~/.config/aicostmanager/queue.db` | Path to SQLite database for persistent queue |
 | `AICM_TIMEOUT` | `10.0` | HTTP timeout in seconds |
 | `AICM_POLL_INTERVAL` | `0.1` | Poll interval for persistent queue workers |
 | `AICM_BATCH_INTERVAL` | `0.5` | Flush interval for queued deliveries |
 | `AICM_MAX_ATTEMPTS` | `3` | Retry attempts for HTTP failures |
 | `AICM_MAX_RETRIES` | `5` | Reschedule attempts for queued items |
 | `AICM_MAX_BATCH_SIZE` | `1000` | Maximum payloads delivered per batch |
-| `AICM_LOG_FILE` | – | Path to a log file |
+| `AICM_LOG_FILE` | `~/.config/aicostmanager/aicm.log` | Path to a log file |
 | `AICM_LOG_LEVEL` | `INFO` | Logging level |
 | `AICM_LOG_BODIES` | `false` | Include request bodies in logs |
+| `AICM_DELIVERY_LOG_BODIES` | `false` | Legacy alias for `AICM_LOG_BODIES` |
+| `AICM_IMMEDIATE_PAUSE_SECONDS` | `5.0` | Post-send wait before checking limits |
 | `AICM_LIMITS_ENABLED` | `false` | Enable triggered limit checks during delivery |
-
-\* If `AICM_DB_PATH` is set and `AICM_DELIVERY_TYPE` is not specified, the
-tracker defaults to `PERSISTENT_QUEUE`.
 

--- a/docs/llm_wrappers.md
+++ b/docs/llm_wrappers.md
@@ -45,8 +45,14 @@ wrapper.close()  # required only for queued delivery
 
 The wrapper proxies every attribute on the client, so existing code typically
 requires only one extra line to instantiate the wrapper.  A tracker is created
-internally using the ``AICM_API_KEY`` environment variable.  Pass ``aicm_api_key``
-or ``tracker`` to the wrapper constructor to override this behaviour.
+internally using the ``AICM_API_KEY`` environment variable.  Pass ``aicm_api_key``,
+``delivery_type`` or ``tracker`` to the wrapper constructor to override this
+behaviour.
+
+```python
+# Use a queue-based delivery strategy
+wrapper = OpenAIChatWrapper(client, delivery_type="PERSISTENT_QUEUE")
+```
 
 ## Streaming responses
 

--- a/docs/persistent_delivery.md
+++ b/docs/persistent_delivery.md
@@ -17,8 +17,8 @@ Values can be supplied directly or through environment variables and the
 - `AICM_API_KEY`
 - `AICM_API_BASE` (default: `https://aicostmanager.com`)
 - `AICM_API_URL` (default: `/api/v1`)
-- `AICM_DB_PATH`
-- `AICM_LOG_FILE`
+- `AICM_DB_PATH` (default: `~/.config/aicostmanager/queue.db`)
+- `AICM_LOG_FILE` (default: `~/.config/aicostmanager/aicm.log`)
 - `AICM_LOG_LEVEL`
 - `AICM_LOG_BODIES`
 - `AICM_TIMEOUT`

--- a/docs/persistent_delivery_logging.md
+++ b/docs/persistent_delivery_logging.md
@@ -20,7 +20,7 @@ export AICM_LOG_LEVEL=DEBUG
 
 ### Log Destination
 
-By default logs are written to ``stdout`` via a ``StreamHandler``.  Provide ``log_file`` (or ``AICM_LOG_FILE``) to write to a file instead.  The parent directory is created automatically.
+By default logs are written to ``~/.config/aicostmanager/aicm.log``.  Provide ``log_file`` (or ``AICM_LOG_FILE``) to change the destination.  The parent directory is created automatically.
 
 ```python
 delivery = PersistentDelivery(log_file="/var/log/aicm/delivery.log")

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -56,14 +56,19 @@ synchronously with up to three retries for transient errors. Use
 ``PERSISTENT_QUEUE`` for a durable SQLite-backed queue with background
 delivery.
 
-### Method 1: Environment variable (simplest)
+### Method 1: Constructor argument (highest precedence)
+```python
+tracker = Tracker(delivery_type="PERSISTENT_QUEUE")
+```
+
+### Method 2: Environment variable (simplest)
 ```python
 import os
 os.environ['AICM_DELIVERY_TYPE'] = 'PERSISTENT_QUEUE'
 tracker = Tracker()
 ```
 
-### Method 2: Direct delivery instance (recommended for web apps)
+### Method 3: Direct delivery instance (recommended for web apps)
 ```python
 from aicostmanager import PersistentDelivery
 # Simple initialization with intelligent defaults
@@ -71,7 +76,7 @@ persistent_delivery = PersistentDelivery()
 tracker = Tracker(delivery=persistent_delivery)
 ```
 
-### Method 3: INI file configuration
+### Method 4: INI file configuration
 Set ``AICM_DELIVERY_TYPE`` in ``AICM.INI``:
 ```ini
 [tracker]

--- a/tests/test_tracker_option_precedence.py
+++ b/tests/test_tracker_option_precedence.py
@@ -1,4 +1,5 @@
 from aicostmanager import Tracker
+from aicostmanager.delivery import DeliveryType
 from aicostmanager.ini_manager import IniManager
 
 
@@ -30,7 +31,7 @@ def test_immediate_timeout_env_over_default(tmp_path, monkeypatch):
 def test_persistent_poll_interval_ini_over_env(tmp_path, monkeypatch):
     ini_path = tmp_path / "AICM.INI"
     ini = IniManager(str(ini_path))
-    ini.set_option("tracker", "AICM_DB_PATH", str(tmp_path / "queue.db"))
+    ini.set_option("tracker", "AICM_DELIVERY_TYPE", "PERSISTENT_QUEUE")
     ini.set_option("tracker", "AICM_POLL_INTERVAL", "5.0")
     monkeypatch.setenv("AICM_POLL_INTERVAL", "7.0")
 
@@ -43,12 +44,41 @@ def test_persistent_poll_interval_ini_over_env(tmp_path, monkeypatch):
 
 def test_persistent_poll_interval_env_over_default(tmp_path, monkeypatch):
     ini_path = tmp_path / "AICM.INI"
-    ini = IniManager(str(ini_path))
-    ini.set_option("tracker", "AICM_DB_PATH", str(tmp_path / "queue.db"))
+    IniManager(str(ini_path))
+    monkeypatch.setenv("AICM_DELIVERY_TYPE", "PERSISTENT_QUEUE")
     monkeypatch.setenv("AICM_POLL_INTERVAL", "7.0")
 
     tracker = Tracker(aicm_api_key="test", ini_path=str(ini_path))
     try:
         assert tracker.delivery.poll_interval == 7.0
+    finally:
+        tracker.close()
+
+
+def test_db_path_does_not_force_persistent(tmp_path):
+    ini_path = tmp_path / "AICM.INI"
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_DB_PATH", str(tmp_path / "queue.db"))
+
+    tracker = Tracker(aicm_api_key="test", ini_path=str(ini_path))
+    try:
+        assert tracker.delivery.type == DeliveryType.IMMEDIATE
+    finally:
+        tracker.close()
+
+
+def test_delivery_type_argument_overrides_config(tmp_path, monkeypatch):
+    ini_path = tmp_path / "AICM.INI"
+    ini = IniManager(str(ini_path))
+    ini.set_option("tracker", "AICM_DELIVERY_TYPE", "PERSISTENT_QUEUE")
+    monkeypatch.setenv("AICM_DELIVERY_TYPE", "PERSISTENT_QUEUE")
+
+    tracker = Tracker(
+        aicm_api_key="test",
+        ini_path=str(ini_path),
+        delivery_type=DeliveryType.IMMEDIATE,
+    )
+    try:
+        assert tracker.delivery.type == DeliveryType.IMMEDIATE
     finally:
         tracker.close()

--- a/tests/test_wrapper_delivery_type.py
+++ b/tests/test_wrapper_delivery_type.py
@@ -1,0 +1,27 @@
+import types
+
+from aicostmanager import OpenAIChatWrapper
+
+
+def test_wrapper_forwards_delivery_type(monkeypatch):
+    captured = {}
+
+    class StubTracker:
+        def __init__(self, *args, **kwargs):
+            captured['delivery_type'] = kwargs.get('delivery_type')
+
+        def track(self, *args, **kwargs):
+            pass
+
+        async def track_async(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr('aicostmanager.wrappers.Tracker', StubTracker)
+
+    client = types.SimpleNamespace()
+    wrapper = OpenAIChatWrapper(client, delivery_type="PERSISTENT_QUEUE")
+    assert captured['delivery_type'] == "PERSISTENT_QUEUE"
+    wrapper.close()


### PR DESCRIPTION
## Summary
- supply default log file and database paths relative to the INI directory
- allow Tracker and LLM wrappers to choose delivery type directly without DB path side effects
- document constructor-based delivery selection for trackers and wrappers

## Testing
- `AICM_API_KEY=test .venv/bin/pytest tests/test_tracker_option_precedence.py tests/test_llm_wrappers.py tests/test_wrapper_delivery_type.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0548eee08832b844d31f524973135