### PR TITLE
feat: make immediate delivery error handling configurable

### DIFF
--- a/aicostmanager/delivery/factory.py
+++ b/aicostmanager/delivery/factory.py
@@ -61,4 +61,11 @@ def create_delivery(
     else:
         log_bodies = bool(log_bodies)
 
-    return ImmediateDelivery(config, log_bodies=log_bodies)
+    raise_on_error = kwargs.get("raise_on_error")
+    if raise_on_error is None:
+        env_val = os.getenv("AICM_RAISE_ON_ERROR", "true")
+        raise_on_error = str(env_val).lower() in {"1", "true", "yes", "on"}
+    else:
+        raise_on_error = bool(raise_on_error)
+
+    return ImmediateDelivery(config, log_bodies=log_bodies, raise_on_error=raise_on_error)

--- a/aicostmanager/tracker.py
+++ b/aicostmanager/tracker.py
@@ -64,6 +64,9 @@ class Tracker:
         )
         log_bodies = str(log_bodies_val).lower() in {"1", "true", "yes", "on"}
 
+        raise_on_error_val = _get("AICM_RAISE_ON_ERROR", "true")
+        raise_on_error = str(raise_on_error_val).lower() in {"1", "true", "yes", "on"}
+
         db_path = _get("AICM_DB_PATH", str(ini_dir / "queue.db"))
         delivery_name_cfg = _get("AICM_DELIVERY_TYPE")
 
@@ -107,6 +110,7 @@ class Tracker:
                 max_retries=max_retries,
                 max_batch_size=max_batch_size,
                 log_bodies=log_bodies,
+                raise_on_error=raise_on_error,
             )
         if resolved_type is not None:
             self.ini_manager.set_option(

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,6 +30,7 @@ All configuration keys are fully capitalised and prefixed with `AICM_`.
 | `AICM_LOG_LEVEL` | `INFO` | Logging level |
 | `AICM_LOG_BODIES` | `false` | Include request bodies in logs |
 | `AICM_DELIVERY_LOG_BODIES` | `false` | Legacy alias for `AICM_LOG_BODIES` |
+| `AICM_RAISE_ON_ERROR` | `true` | Raise exceptions when immediate tracking fails |
 | `AICM_IMMEDIATE_PAUSE_SECONDS` | `5.0` | Post-send wait before checking limits |
 | `AICM_LIMITS_ENABLED` | `false` | Enable triggered limit checks during delivery |
 

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -52,7 +52,8 @@ See [`config.md`](config.md) for the full list of settings.
 ## Choosing a delivery manager
 
 The tracker supports multiple delivery strategies. The default ``IMMEDIATE`` mode sends each record
-synchronously with up to three retries for transient errors. Use
+synchronously with up to three retries for transient errors. By default, a failure to reach the
+tracking API raises an exception; set ``AICM_RAISE_ON_ERROR=false`` to log and continue. Use
 ``PERSISTENT_QUEUE`` for a durable SQLite-backed queue with background
 delivery.
 


### PR DESCRIPTION
## Summary
- add `raise_on_error` option to ImmediateDelivery and expose `AICM_RAISE_ON_ERROR`
- wire error handling config through tracker and delivery factory
- document new setting and test both raising and continuing behaviours

## Testing
- `python -m py_compile aicostmanager/delivery/immediate.py aicostmanager/delivery/factory.py aicostmanager/tracker.py tests/test_delivery_manager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68b0dc0da5a0832b94824b6b1c2bdab9