### PR TITLE
Remove legacy track-usage endpoint

### DIFF
--- a/aicostmanager/client/async_client.py
+++ b/aicostmanager/client/async_client.py
@@ -5,8 +5,6 @@ from typing import Any, AsyncIterator, Dict, Iterable, Optional
 import httpx
 
 from ..models import (
-    ApiUsageRequest,
-    ApiUsageResponse,
     CostUnitOut,
     CustomerFilters,
     CustomerIn,
@@ -100,18 +98,6 @@ class AsyncCostManagerClient(BaseClient):
     async def get_triggered_limits(self) -> Dict[str, Any]:
         """Asynchronously fetch triggered limit information."""
         return await self._request("GET", "/triggered-limits")
-
-    async def track_usage(
-        self, data: ApiUsageRequest | Dict[str, Any]
-    ) -> ApiUsageResponse:
-        payload = (
-            data.model_dump(mode="json") if isinstance(data, ApiUsageRequest) else data
-        )
-        resp = await self._request("POST", "/track-usage", json=payload)
-        result = ApiUsageResponse.model_validate(resp)
-        # Always update triggered_limits, even if empty - server may have cleared previous limits
-        self._store_triggered_limits(result.triggered_limits or {})
-        return result
 
     async def list_usage_events(
         self,

--- a/aicostmanager/client/sync_client.py
+++ b/aicostmanager/client/sync_client.py
@@ -6,8 +6,6 @@ import os
 import requests
 
 from ..models import (
-    ApiUsageRequest,
-    ApiUsageResponse,
     CostUnitOut,
     CustomerFilters,
     CustomerIn,
@@ -124,16 +122,6 @@ class CostManagerClient(BaseClient):
     def get_triggered_limits(self) -> Dict[str, Any]:
         """Fetch triggered limit information from the API."""
         return self._request("GET", "/triggered-limits")
-
-    def track_usage(self, data: ApiUsageRequest | Dict[str, Any]) -> ApiUsageResponse:
-        payload = (
-            data.model_dump(mode="json") if isinstance(data, ApiUsageRequest) else data
-        )
-        resp = self._request("POST", "/track-usage", json=payload)
-        result = ApiUsageResponse.model_validate(resp)
-        # Always update triggered_limits, even if empty - server may have cleared previous limits
-        self._store_triggered_limits(result.triggered_limits or {})
-        return result
 
     def list_usage_events(
         self,

--- a/aicostmanager/models/__init__.py
+++ b/aicostmanager/models/__init__.py
@@ -9,9 +9,6 @@ from .common import (
     ValidationError,
 )
 from .usage import (
-    ApiUsageRecord,
-    ApiUsageRequest,
-    ApiUsageResponse,
     RollupFilters,
     UsageEvent,
     UsageEventFilters,
@@ -30,9 +27,6 @@ __all__ = [
     "Period",
     "ThresholdType",
     "ValidationError",
-    "ApiUsageRecord",
-    "ApiUsageRequest",
-    "ApiUsageResponse",
     "RollupFilters",
     "UsageEvent",
     "UsageEventFilters",

--- a/aicostmanager/models/usage.py
+++ b/aicostmanager/models/usage.py
@@ -1,39 +1,11 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from .common import Granularity
-
-
-class ApiUsageRecord(BaseModel):
-    """Individual usage record for /track-usage"""
-
-    config_id: str
-    service_id: str
-    timestamp: str
-    response_id: str
-    usage: Dict[str, Any]
-    base_url: Optional[str] = None
-    client_customer_key: Optional[str] = None
-    context: Optional[Dict[str, Any]] = None
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class ApiUsageRequest(BaseModel):
-    """Request body for /track-usage"""
-
-    usage_records: List[ApiUsageRecord]
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class ApiUsageResponse(BaseModel):
-    event_ids: List[Dict[str, str]]
-    triggered_limits: Dict[str, str]
 
 
 class UsageEvent(BaseModel):

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -106,7 +106,7 @@ Inside route handlers, use the tracker to send usage data:
 from fastapi import Request
 
 @app.post("/track")
-async def track_usage(request: Request) -> dict:
+async def track(request: Request) -> dict:
     payload = await request.json()
     app.state.tracker.track("openai", "gpt-4o-mini", payload)
     return {"status": "queued"}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,7 +102,7 @@ def shutdown() -> None:
 
 
 @app.post("/track")
-async def track_usage(payload: dict) -> dict:
+async def track(payload: dict) -> dict:
     app.state.tracker.track(payload)
     return {"status": "ok"}
 ```

--- a/tests/test_llm_wrappers.py
+++ b/tests/test_llm_wrappers.py
@@ -183,7 +183,7 @@ def make_bedrock_client():
     return Client()
 
 
-def test_wrappers_track_usage_non_streaming():
+def test_wrappers_track_non_streaming():
     tracker = DummyTracker()
     cases = [
         (


### PR DESCRIPTION
## Summary
- drop ApiUsage* models and the client `track_usage` methods
- update docs and tests to stop referencing legacy `/track-usage`

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68b0ec9c58b8832baf8e043b4984b7f1