### PR TITLE
Use service_key for triggered limit matching

### DIFF
--- a/aicostmanager/delivery/immediate.py
+++ b/aicostmanager/delivery/immediate.py
@@ -123,22 +123,10 @@ class ImmediateDelivery(Delivery):
                 cfg_limits = cfg
                 request_service_key = payload.get("service_key")
                 client_customer_key = payload.get("client_customer_key")
-                vendor = service_id = None
-                if isinstance(request_service_key, str) and "::" in request_service_key:
-                    vendor, service_id = request_service_key.split("::", 1)
-                elif isinstance(request_service_key, str):
-                    service_id = request_service_key
                 limits = cfg_limits.get_triggered_limits(
-                    service_id=service_id,
-                    service_vendor=vendor,
+                    service_key=request_service_key,
                     client_customer_key=client_customer_key,
                 )
-                if request_service_key:
-                    limits = [
-                        l
-                        for l in limits
-                        if getattr(l, "service_key", None) == request_service_key
-                    ]
                 api_key_id = (
                     self.api_key.split(".")[-1]
                     if self.api_key and "." in self.api_key

--- a/aicostmanager/limits/triggered.py
+++ b/aicostmanager/limits/triggered.py
@@ -40,14 +40,8 @@ class TriggeredLimitManager(BaseLimitManager):
         service_key: Optional[str] = None,
         client_customer_key: Optional[str] = None,
     ) -> List[TriggeredLimit]:
-        vendor = service_id = None
-        if service_key and "::" in service_key:
-            vendor, service_id = service_key.split("::", 1)
-        elif service_key:
-            service_id = service_key
         limits = self.config_manager.get_triggered_limits(
-            service_id=service_id,
-            service_vendor=vendor,
+            service_key=service_key,
             client_customer_key=client_customer_key,
         )
         return [l for l in limits if l.api_key_id == api_key_id]

--- a/docs/limit_managers.md
+++ b/docs/limit_managers.md
@@ -67,10 +67,11 @@ tl_mgr = TriggeredLimitManager(client)
 # Refresh the local cache of triggered limits
 tl_mgr.update_triggered_limits()
 
-# Filter triggered events for an API key and service
+# Filter triggered events for an API key, service, and optional client key
 events = tl_mgr.check_triggered_limits(
     api_key_id="550e8400-e29b-41d4-a716-446655440000",
     service_key="openai::gpt-4",
+    client_customer_key="customer1",
 )
 for tl in events:
     print(tl.limit_id, tl.threshold_type)

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -114,9 +114,12 @@ tracker.track(
 ### Triggered limit enforcement
 
 Every delivery mechanism refreshes triggered limit data from the API after
-successfully sending a batch. The decrypted limits are cached in memory and
-persisted to ``AICM.ini`` as a fallback. Enqueued payloads are compared against
-this in-memory cache and
+successfully sending a batch. Triggered limits are matched by API key ID and
+optionally by ``client_customer_key`` and ``service_key``. The service key is
+treated as an opaque value and is **not** split into vendor and service
+components. The decrypted limits are cached in memory and persisted to
+``AICM.ini`` as a fallback. Enqueued payloads are compared against this
+in-memory cache and
 :class:`~aicostmanager.client.exceptions.UsageLimitExceeded` is raised if the
 payload matches a triggered limit. The check occurs *after* the enqueue or
 delivery action so tracking data is never discarded even when a limit has been

--- a/tests/test_limits_manager.py
+++ b/tests/test_limits_manager.py
@@ -61,6 +61,9 @@ def test_update_and_check(monkeypatch, tmp_path):
     stored = cfg_mgr.read_triggered_limits()
     assert stored.get("encrypted_payload") == item["encrypted_payload"]
 
+    cfg_matches = cfg_mgr.get_triggered_limits(service_key=event["service_key"])
+    assert len(cfg_matches) == 1
+
     matches = tl_mgr.check_triggered_limits(
         api_key_id=event["api_key_id"], service_key=event["service_key"]
     )


### PR DESCRIPTION
## Summary
- remove vendor/service id handling from triggered limit checks
- document service_key-based matching
- add regression test for ConfigManager get_triggered_limits

## Testing
- `pytest tests/test_delivery_triggered_limits.py tests/test_limits_manager.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_b_68b106de5598832b833b62c5f7a3ef00