### PR TITLE
Handle user-specific triggered limits

### DIFF
--- a/aicostmanager/triggered_limits_cache.py
+++ b/aicostmanager/triggered_limits_cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from threading import RLock
-from typing import Any, List, Optional
+from typing import List, Optional
 
 
 class TriggeredLimitsCache:
@@ -11,6 +11,7 @@ class TriggeredLimitsCache:
         self._lock = RLock()
         self._data: Optional[List[dict]] = None
         self._raw: Optional[dict] = None
+        self._user: Optional[str] = None
 
     def get(self) -> Optional[List[dict]]:
         with self._lock:
@@ -20,16 +21,25 @@ class TriggeredLimitsCache:
         with self._lock:
             return self._raw
 
-    def set(self, value: List[dict], raw: Optional[dict] = None) -> None:
+    def get_user(self) -> Optional[str]:
+        """Return the user associated with the cached triggered limits."""
+        with self._lock:
+            return self._user
+
+    def set(
+        self, value: List[dict], raw: Optional[dict] = None, user: Optional[str] = None
+    ) -> None:
         with self._lock:
             self._data = value
             if raw is not None:
                 self._raw = raw
+            self._user = user
 
     def clear(self) -> None:
         with self._lock:
             self._data = None
             self._raw = None
+            self._user = None
 
 
 triggered_limits_cache = TriggeredLimitsCache()


### PR DESCRIPTION
## Summary
- track user identity in triggered limits cache
- store and filter triggered limits by user when fetching and checking
- test user-specific triggered limit matching

## Testing
- `python -m py_compile aicostmanager/triggered_limits_cache.py aicostmanager/config_manager.py tests/test_limits_manager.py`
- `pytest tests/test_limits_manager.py::test_triggered_limit_user_filter -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest tests/test_delivery_triggered_limits.py::test_immediate_enforce_triggered_limit -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_b_68b1c31ef2f8832bafa5651fd6c4b953